### PR TITLE
Handle backdrop click as outside-click

### DIFF
--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -23,11 +23,12 @@
 
   <script>
     describe('overlay', function() {
-      var overlay, parent, backdrop;
+      var overlay, parent, content, backdrop;
 
       beforeEach(function() {
         parent = fixture('default').children[0];
         overlay = parent.children[0];
+        content = overlay.$.content;
         backdrop = overlay.$.backdrop;
         overlay._observer.flush();
         overlay.opened = true;
@@ -75,17 +76,32 @@
         expect(overlay.opened).to.be.true;
       });
 
+      it('should not close on inside click', () => {
+        content.click();
+
+        expect(overlay.opened).to.be.true;
+      });
+
       it('should close on outside click', () => {
         parent.click();
 
         expect(overlay.opened).to.be.false;
       });
 
-      it('should not close if vaadin-overlay-outside-click event was canceled', () => {
+      it('should not close on outside click if vaadin-overlay-outside-click event was canceled', () => {
         overlay.addEventListener('vaadin-overlay-outside-click', e => {
           e.preventDefault();
         });
         parent.click();
+
+        expect(overlay.opened).to.be.true;
+      });
+
+      it('should not close on backdrop click if vaadin-overlay-outside-click event was canceled', () => {
+        overlay.addEventListener('vaadin-overlay-outside-click', e => {
+          e.preventDefault();
+        });
+        backdrop.click();
 
         expect(overlay.opened).to.be.true;
       });

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -55,7 +55,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     </style>
 
-    <div id="backdrop" part="backdrop" on-tap="close" hidden$="{{!withBackdrop}}">
+    <div id="backdrop" part="backdrop" on-tap="_outsideClickListener" hidden$="{{!withBackdrop}}">
 
     </div>
     <div part="content" id="content">
@@ -149,8 +149,7 @@ This program is available under Apache License Version 2.0, available at https:/
        * We need to listen on 'click' / 'tap' event and capture it and close the overlay before
        * propagating the event to the listener in the button. Otherwise, if the clicked button would call
        * open(), this would happen: https://www.youtube.com/watch?v=Z86V_ICUCD4
-       */
-      /**
+       *
        * @event vaadin-overlay-outside-click
        * fired before the `vaadin-overlay` will be closed on outside click. If canceled the closing of the overlay is canceled as well.
        */
@@ -158,7 +157,7 @@ This program is available under Apache License Version 2.0, available at https:/
         const evt = new CustomEvent('vaadin-overlay-outside-click', {bubbles: true, cancelable: true, detail: {sourceEvent: event}});
         this.dispatchEvent(evt);
 
-        if (this.opened && event.composedPath().indexOf(this) < 0 && !evt.defaultPrevented) {
+        if (this.opened && event.composedPath().indexOf(this.$.content) < 0 && !evt.defaultPrevented) {
           this.close(event);
         }
       }


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-overlay/pull/5

Answering my own question :)

> will this solution work for both cases: with and without backdrop?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/8)
<!-- Reviewable:end -->
