### PR TITLE
Remove border-radius from default theme

### DIFF
--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -15,7 +15,6 @@ This program is available under Apache License Version 2.0, available at https:/
     <style>
       [part="content"] {
         background: #fff;
-        border-radius: 0 0 2px 2px;
         -webkit-overflow-scrolling: touch;
         overflow: auto;
       }


### PR DESCRIPTION
No idea why it was here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/9)
<!-- Reviewable:end -->
