### PR TITLE
Fix _escapeListener to prevent throwing event when not needed

### DIFF
--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -66,6 +66,17 @@
         expect(backdrop.hidden).to.be.false;
       });
 
+      it('should fire the vaadin-overlay-escape-press event only when ESC pressed', function(done) {
+        var doneHandler = () => done();
+
+        overlay.addEventListener('vaadin-overlay-escape-press', doneHandler, false);
+
+        MockInteractions.pressAndReleaseKeyOn(document.body, 27);
+        MockInteractions.pressAndReleaseKeyOn(document.body, 13);
+
+        overlay.removeEventListener('vaadin-overlay-escape-press', doneHandler, false);
+      });
+
       it('should not close on esc if vaadin-overlay-escape-press event was canceled', () => {
         overlay.addEventListener('vaadin-overlay-escape-press', e => {
           e.preventDefault();

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -166,11 +166,13 @@ This program is available under Apache License Version 2.0, available at https:/
        * fired before the `vaadin-overlay` will be closed on ESC button press. If canceled the closing of the overlay is canceled as well.
        */
       _escapeListener(event) {
-        const evt = new CustomEvent('vaadin-overlay-escape-press', {bubbles: true, cancelable: true, detail: {sourceEvent: event}});
-        this.dispatchEvent(evt);
+        if (event.keyCode === 27) {
+          const evt = new CustomEvent('vaadin-overlay-escape-press', {bubbles: true, cancelable: true, detail: {sourceEvent: event}});
+          this.dispatchEvent(evt);
 
-        if (this.opened && event.keyCode === 27 && !evt.defaultPrevented) {
-          this.close(event);
+          if (this.opened && !evt.defaultPrevented) {
+            this.close(event);
+          }
         }
       }
 


### PR DESCRIPTION
Before this change `vaadin-overlay-escape-press` was thrown on every keydown event :upside_down_face:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/10)
<!-- Reviewable:end -->
