### PR TITLE
Add vaadin-overlay-tab-press event

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -8,11 +8,11 @@
       "sourceRange": {
         "file": "vaadin-overlay.html",
         "start": {
-          "line": 236,
+          "line": 249,
           "column": 4
         },
         "end": {
-          "line": 236,
+          "line": 249,
           "column": 40
         }
       },
@@ -207,16 +207,16 @@
               ]
             },
             {
-              "name": "_escapeListener",
+              "name": "_keydownListener",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 170,
+                  "line": 166,
                   "column": 6
                 },
                 "end": {
-                  "line": 179,
+                  "line": 192,
                   "column": 7
                 }
               },
@@ -233,11 +233,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 181,
+                  "line": 194,
                   "column": 6
                 },
                 "end": {
-                  "line": 205,
+                  "line": 218,
                   "column": 7
                 }
               },
@@ -254,11 +254,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 207,
+                  "line": 220,
                   "column": 6
                 },
                 "end": {
-                  "line": 218,
+                  "line": 231,
                   "column": 7
                 }
               },
@@ -275,11 +275,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 220,
+                  "line": 233,
                   "column": 6
                 },
                 "end": {
-                  "line": 222,
+                  "line": 235,
                   "column": 7
                 }
               },
@@ -296,11 +296,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 224,
+                  "line": 237,
                   "column": 6
                 },
                 "end": {
-                  "line": 228,
+                  "line": 241,
                   "column": 7
                 }
               },
@@ -350,7 +350,7 @@
               "column": 4
             },
             "end": {
-              "line": 229,
+              "line": 242,
               "column": 5
             }
           },
@@ -433,13 +433,19 @@
             {
               "type": "CustomEvent",
               "name": "vaadin-overlay-escape-press",
-              "description": "vaadin-overlay-escape-press\nfired before the `vaadin-overlay` will be closed on ESC button press. If canceled the closing of the overlay is canceled as well.",
+              "description": "vaadin-overlay-escape-press\nfired before the `vaadin-overlay` will be closed on ESC button press.\nIf canceled the closing of the overlay is canceled as well.",
               "metadata": {}
             },
             {
               "type": "CustomEvent",
               "name": "vaadin-overlay-outside-click",
               "description": "vaadin-overlay-outside-click\nfired before the `vaadin-overlay` will be closed on outside click. If canceled the closing of the overlay is canceled as well.",
+              "metadata": {}
+            },
+            {
+              "type": "CustomEvent",
+              "name": "vaadin-overlay-tab-press",
+              "description": "vaadin-overlay-tab-press\nfired before the TAB button press.",
               "metadata": {}
             },
             {

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -87,6 +87,17 @@
         expect(overlay.opened).to.be.true;
       });
 
+      it('should fire the vaadin-overlay-tab-press event only when TAB pressed', function(done) {
+        var doneHandler = () => done();
+
+        overlay.addEventListener('vaadin-overlay-tab-press', doneHandler, false);
+
+        MockInteractions.pressAndReleaseKeyOn(document.body, 9);
+        MockInteractions.pressAndReleaseKeyOn(document.body, 13);
+
+        overlay.removeEventListener('vaadin-overlay-tab-press', doneHandler, false);
+      });
+
       it('should not close on inside click', () => {
         content.click();
 

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -114,7 +114,7 @@ This program is available under Apache License Version 2.0, available at https:/
       constructor() {
         super();
         this._boundOutsideClickListener = this._outsideClickListener.bind(this);
-        this._boundEscapeListener = this._escapeListener.bind(this);
+        this._boundKeydownListener = this._keydownListener.bind(this);
 
         this._observer = new Polymer.FlattenedNodesObserver(this, info => {
           this._setTemplateFromNodes(info.addedNodes);
@@ -164,12 +164,25 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       }
 
-      /**
-       * @event vaadin-overlay-escape-press
-       * fired before the `vaadin-overlay` will be closed on ESC button press. If canceled the closing of the overlay is canceled as well.
-       */
-      _escapeListener(event) {
-        if (event.keyCode === 27) {
+      _keydownListener(event) {
+        /**
+         * @event vaadin-overlay-tab-press
+         * fired before the TAB button press.
+         */
+        if (event.keyCode === 9) {
+          const evt = new CustomEvent('vaadin-overlay-tab-press', {bubbles: true, cancelable: true, detail: {sourceEvent: event}});
+          this.dispatchEvent(evt);
+
+          if (evt.defaultPrevented) {
+            event.preventDefault();
+          }
+
+        /**
+         * @event vaadin-overlay-escape-press
+         * fired before the `vaadin-overlay` will be closed on ESC button press.
+         * If canceled the closing of the overlay is canceled as well.
+         */
+        } else if (event.keyCode === 27) {
           const evt = new CustomEvent('vaadin-overlay-escape-press', {bubbles: true, cancelable: true, detail: {sourceEvent: event}});
           this.dispatchEvent(evt);
 
@@ -186,7 +199,7 @@ This program is available under Apache License Version 2.0, available at https:/
           document.body.appendChild(this);
 
           document.addEventListener('click', this._boundOutsideClickListener, true);
-          document.addEventListener('keydown', this._boundEscapeListener);
+          document.addEventListener('keydown', this._boundKeydownListener);
 
           // Set body pointer-events to 'none' to disable mouse interactions with
           // other document nodes (combo-box is "modal")
@@ -195,7 +208,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         } else if (this._placeholder) {
           document.removeEventListener('click', this._boundOutsideClickListener, true);
-          document.removeEventListener('keydown', this._boundEspaceListener);
+          document.removeEventListener('keydown', this._boundKeydownListener);
 
           this._placeholder.parentNode.insertBefore(this, this._placeholder);
           this._processPendingMutationObserversFor(document.body);


### PR DESCRIPTION
Tab event is needed for the focus trap in `vaadin-dialog`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/13)
<!-- Reviewable:end -->
