### PR TITLE
_boundIronOverlayCanceledListener event listener

### DIFF
--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -203,6 +203,18 @@
         expect(overlay.opened).to.be.false;
       });
 
+      it('should prevent `iron-overlay-canceled` when is opened', () => {
+        const evtOnOpened = new CustomEvent('iron-overlay-canceled', {bubbles: true, cancelable: true});
+        parent.dispatchEvent(evtOnOpened);
+        expect(evtOnOpened.defaultPrevented).to.be.true;
+
+        parent.click();
+
+        const evtOnClosed = new CustomEvent('iron-overlay-canceled', {bubbles: true, cancelable: true});
+        parent.dispatchEvent(evtOnClosed);
+        expect(evtOnClosed.defaultPrevented).to.be.false;
+      });
+
       it('should prevent closing the overlay when preventing vaadin-overlay-cancel', done => {
         overlay.addEventListener('vaadin-overlay-close', e => {
           e.preventDefault();

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -114,6 +114,10 @@ This program is available under Apache License Version 2.0, available at https:/
 
           _instance: {
             type: Object
+          },
+
+          _boundIronOverlayCanceledListener: {
+            type: Object
           }
         };
       }
@@ -130,6 +134,12 @@ This program is available under Apache License Version 2.0, available at https:/
         this._observer = new Polymer.FlattenedNodesObserver(this, info => {
           this._setTemplateFromNodes(info.addedNodes);
         });
+
+        // Listener for preventing closing of the paper-dialog and all components extending `iron-overlay-behavior`.
+        this._boundIronOverlayCanceledListener = e => {
+          e.preventDefault();
+          window.removeEventListener('iron-overlay-canceled', this._boundIronOverlayCanceledListener);
+        };
       }
 
       ready() {
@@ -151,6 +161,15 @@ This program is available under Apache License Version 2.0, available at https:/
         this.dispatchEvent(evt);
         if (!evt.defaultPrevented) {
           this.opened = false;
+        }
+      }
+
+      disconnectedCallback() {
+        super.disconnectedCallback();
+
+        // Removing the event listener in case `iron-overlay-canceled` was not fired.
+        if (!this.parentNode) {
+          window.removeEventListener('iron-overlay-canceled', this._boundIronOverlayCanceledListener);
         }
       }
 
@@ -213,6 +232,7 @@ This program is available under Apache License Version 2.0, available at https:/
        */
       _openedChanged(opened) {
         if (opened) {
+          window.addEventListener('iron-overlay-canceled', this._boundIronOverlayCanceledListener);
           this._placeholder = document.createComment('vaadin-overlay-placeholder');
           this.parentNode.insertBefore(this._placeholder, this);
           document.body.appendChild(this);

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -164,12 +164,27 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       }
 
+      connectedCallback() {
+        super.connectedCallback();
+
+        if (this.parentNode === document.body) {
+          window.addEventListener('iron-overlay-canceled', this._boundIronOverlayCanceledListener);
+        }
+      }
+
       disconnectedCallback() {
         super.disconnectedCallback();
 
         // Removing the event listener in case `iron-overlay-canceled` was not fired.
-        if (!this.parentNode) {
-          window.removeEventListener('iron-overlay-canceled', this._boundIronOverlayCanceledListener);
+        // In Shady DOM the overlay can be reattached asynchronously so we need to check that the overlay is not currently attached to body.
+        if (window.ShadyDOM && window.ShadyDOM.inUse) {
+          if (this.parentNode !== document.body) {
+            window.removeEventListener('iron-overlay-canceled', this._boundIronOverlayCanceledListener);
+          }
+        } else {
+          if (!this.parentNode) {
+            window.removeEventListener('iron-overlay-canceled', this._boundIronOverlayCanceledListener);
+          }
         }
       }
 
@@ -232,7 +247,6 @@ This program is available under Apache License Version 2.0, available at https:/
        */
       _openedChanged(opened) {
         if (opened) {
-          window.addEventListener('iron-overlay-canceled', this._boundIronOverlayCanceledListener);
           this._placeholder = document.createComment('vaadin-overlay-placeholder');
           this.parentNode.insertBefore(this._placeholder, this);
           document.body.appendChild(this);


### PR DESCRIPTION
Adding `_boundIronOverlayCanceledListener` event listener for preventing `iron-overlay-canceled` event to fix issue of `vaadin-combo-box` inside `paper-dialog`.

Connects to https://github.com/vaadin/vaadin-combo-box/issues/405

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/14)
<!-- Reviewable:end -->
