### PR TITLE
Implement focus-trap

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -8,11 +8,11 @@
       "sourceRange": {
         "file": "vaadin-overlay.html",
         "start": {
-          "line": 236,
+          "line": 320,
           "column": 4
         },
         "end": {
-          "line": 236,
+          "line": 320,
           "column": 40
         }
       },
@@ -106,18 +106,57 @@
               "defaultValue": "false"
             },
             {
-              "name": "_instance",
-              "type": "Object",
+              "name": "focusTrap",
+              "type": "boolean",
               "description": "",
-              "privacy": "protected",
+              "privacy": "public",
               "sourceRange": {
                 "start": {
                   "line": 105,
                   "column": 10
                 },
                 "end": {
-                  "line": 105,
-                  "column": 27
+                  "line": 108,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "_focusedElement",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 110,
+                  "column": 10
+                },
+                "end": {
+                  "line": 112,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "_instance",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 114,
+                  "column": 10
+                },
+                "end": {
+                  "line": 116,
+                  "column": 11
                 }
               },
               "metadata": {
@@ -132,11 +171,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 123,
+                  "line": 134,
                   "column": 6
                 },
                 "end": {
-                  "line": 127,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -149,11 +188,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 129,
+                  "line": 140,
                   "column": 6
                 },
                 "end": {
-                  "line": 131,
+                  "line": 142,
                   "column": 7
                 }
               },
@@ -170,11 +209,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 137,
+                  "line": 148,
                   "column": 6
                 },
                 "end": {
-                  "line": 143,
+                  "line": 154,
                   "column": 7
                 }
               },
@@ -191,11 +230,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 153,
+                  "line": 164,
                   "column": 6
                 },
                 "end": {
-                  "line": 164,
+                  "line": 175,
                   "column": 7
                 }
               },
@@ -207,16 +246,16 @@
               ]
             },
             {
-              "name": "_escapeListener",
+              "name": "_keydownListener",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 170,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 179,
+                  "line": 207,
                   "column": 7
                 }
               },
@@ -233,11 +272,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 181,
+                  "line": 213,
                   "column": 6
                 },
                 "end": {
-                  "line": 205,
+                  "line": 247,
                   "column": 7
                 }
               },
@@ -254,11 +293,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 207,
+                  "line": 249,
                   "column": 6
                 },
                 "end": {
-                  "line": 218,
+                  "line": 260,
                   "column": 7
                 }
               },
@@ -275,11 +314,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 220,
+                  "line": 262,
                   "column": 6
                 },
                 "end": {
-                  "line": 222,
+                  "line": 264,
                   "column": 7
                 }
               },
@@ -291,16 +330,78 @@
               ]
             },
             {
+              "name": "_setFocus",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 266,
+                  "column": 6
+                },
+                "end": {
+                  "line": 293,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "index"
+                },
+                {
+                  "name": "increment"
+                }
+              ]
+            },
+            {
+              "name": "_isVisible",
+              "description": "borrowed from jqeury $(elem).is(':visible') implementation",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 296,
+                  "column": 6
+                },
+                "end": {
+                  "line": 298,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "elem"
+                }
+              ]
+            },
+            {
+              "name": "_getFocusableElements",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 300,
+                  "column": 6
+                },
+                "end": {
+                  "line": 306,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
               "name": "_processPendingMutationObserversFor",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 224,
+                  "line": 308,
                   "column": 6
                 },
                 "end": {
-                  "line": 228,
+                  "line": 312,
                   "column": 7
                 }
               },
@@ -350,7 +451,7 @@
               "column": 4
             },
             "end": {
-              "line": 229,
+              "line": 313,
               "column": 5
             }
           },
@@ -421,6 +522,22 @@
               },
               "metadata": {},
               "type": "boolean"
+            },
+            {
+              "name": "focus-trap",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 105,
+                  "column": 10
+                },
+                "end": {
+                  "line": 108,
+                  "column": 11
+                }
+              },
+              "metadata": {},
+              "type": "boolean"
             }
           ],
           "events": [
@@ -434,6 +551,12 @@
               "type": "CustomEvent",
               "name": "vaadin-overlay-escape-press",
               "description": "vaadin-overlay-escape-press\nfired before the `vaadin-overlay` will be closed on ESC button press. If canceled the closing of the overlay is canceled as well.",
+              "metadata": {}
+            },
+            {
+              "type": "CustomEvent",
+              "name": "vaadin-overlay-open",
+              "description": "vaadin-overlay-open\nfired after the `vaadin-overlay` is opened.",
               "metadata": {}
             },
             {

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,11 +30,17 @@
       </template>
     </demo-snippet>
 
-    <h3>Show and Hide Overlay with backdrop</h3>
+    <h3>Show and Hide Overlay with backdrop and focus trap</h3>
     <demo-snippet>
       <template>
-        <vaadin-overlay with-backdrop id="overlay2">
-          Overlay Content with backdrop
+        <vaadin-overlay with-backdrop focus-trap id="overlay2">
+          <template>
+            Focus is trapped inside the content block
+            <button>native button</button>
+            <button tabindex="-1">button with tabindex="-1"</button>
+            <input type="text">
+            <vaadin-button>vaadin-button</vaadin-button>
+          </template>
         </vaadin-overlay>
 
         <vaadin-button onclick="document.querySelector('#overlay2').opened = true">

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -5,6 +5,7 @@
   <title>vaadin-overlay tests</title>
   <script src="../../web-component-tester/browser.js"></script>
   <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+  <link rel="import" href="../../vaadin-button/vaadin-button.html">
   <link rel="import" href="../vaadin-overlay.html">
 </head>
 
@@ -14,7 +15,13 @@
       <div>
         <div id="parent">
           <vaadin-overlay>
-            <template>content</template>
+            <template>
+              content
+              <button>native button</button>
+              <button tabindex="-1">button with tabindex="-1"</button>
+              <input type="text">
+              <vaadin-button>vaadin-button</vaadin-button>
+            </template>
           </vaadin-overlay>
         </div>
       </div>
@@ -23,12 +30,13 @@
 
   <script>
     describe('overlay', function() {
-      var overlay, parent, content, backdrop;
+      var overlay, parent, content, backdrop, focusableElements;
 
       beforeEach(function() {
         parent = fixture('default').children[0];
         overlay = parent.children[0];
         content = overlay.$.content;
+        focusableElements = overlay._getFocusableElements();
         backdrop = overlay.$.backdrop;
         overlay._observer.flush();
         overlay.opened = true;
@@ -50,6 +58,49 @@
 
       it('should stamp contents inside shadow root', () => {
         expect(overlay.root.textContent).to.contain('content');
+      });
+
+      describe('focus trap', function() {
+        beforeEach(function() {
+          window.focus();
+        });
+
+        it('should focus the content when focusTrap = false', (done) => {
+          overlay.addEventListener('vaadin-overlay-open', () => {
+            expect(overlay._focusedElement).to.eql(content);
+            done();
+          });
+        });
+
+        it('should properly detect focusable elements inside the content', () => {
+          expect(focusableElements.length).to.eql(3);
+          expect(focusableElements[0]).to.eql(overlay.$.content.querySelector('button'));
+          expect(focusableElements[1]).to.eql(overlay.$.content.querySelector('input'));
+          expect(focusableElements[2]).to.eql(overlay.$.content.querySelector('vaadin-button'));
+        });
+
+        it('should focus focusable elements inside the content when focusTrap = true', (done) => {
+          overlay.focusTrap = true;
+          overlay.addEventListener('vaadin-overlay-open', () => {
+            // TAB
+            expect(overlay._focusedElement).to.eql(focusableElements[0]);
+            MockInteractions.pressAndReleaseKeyOn(document.body, 9);
+            expect(overlay._focusedElement).to.eql(focusableElements[1]);
+            MockInteractions.pressAndReleaseKeyOn(document.body, 9);
+            expect(overlay._focusedElement).to.eql(focusableElements[2]);
+            MockInteractions.pressAndReleaseKeyOn(document.body, 9);
+            expect(overlay._focusedElement).to.eql(focusableElements[0]);
+
+            // SHIFT+TAB
+            MockInteractions.pressAndReleaseKeyOn(document.body, 9, 'shift');
+            expect(overlay._focusedElement).to.eql(focusableElements[2]);
+            MockInteractions.pressAndReleaseKeyOn(document.body, 9, 'shift');
+            expect(overlay._focusedElement).to.eql(focusableElements[1]);
+            MockInteractions.pressAndReleaseKeyOn(document.body, 9, 'shift');
+            expect(overlay._focusedElement).to.eql(focusableElements[0]);
+            done();
+          });
+        });
       });
 
       it('should close on esc', () => {

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -103,7 +103,18 @@ This program is available under Apache License Version 2.0, available at https:/
             reflectToAttribute: true
           },
 
-          _instance: Object
+          focusTrap: {
+            type: Boolean,
+            value: false
+          },
+
+          _focusedElement: {
+            type: Object
+          },
+
+          _instance: {
+            type: Object
+          }
         };
       }
 
@@ -114,7 +125,7 @@ This program is available under Apache License Version 2.0, available at https:/
       constructor() {
         super();
         this._boundOutsideClickListener = this._outsideClickListener.bind(this);
-        this._boundEscapeListener = this._escapeListener.bind(this);
+        this._boundKeydownListener = this._keydownListener.bind(this);
 
         this._observer = new Polymer.FlattenedNodesObserver(this, info => {
           this._setTemplateFromNodes(info.addedNodes);
@@ -168,8 +179,25 @@ This program is available under Apache License Version 2.0, available at https:/
        * @event vaadin-overlay-escape-press
        * fired before the `vaadin-overlay` will be closed on ESC button press. If canceled the closing of the overlay is canceled as well.
        */
-      _escapeListener(event) {
-        if (event.keyCode === 27) {
+      _keydownListener(event) {
+        // TAB
+        if (event.keyCode === 9 && this.focusTrap) {
+          const focusableElements = this._getFocusableElements();
+          const focusedElementIndex = focusableElements.indexOf(this._focusedElement);
+
+          // Cycle to the next button
+          if (!event.shiftKey) {
+            this._setFocus(focusedElementIndex, 1);
+
+          // Cycle to the prev button
+          } else {
+            this._setFocus(focusedElementIndex, -1);
+          }
+
+          event.preventDefault();
+
+        // ESC
+        } else if (event.keyCode === 27) {
           const evt = new CustomEvent('vaadin-overlay-escape-press', {bubbles: true, cancelable: true, detail: {sourceEvent: event}});
           this.dispatchEvent(evt);
 
@@ -179,6 +207,10 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       }
 
+      /**
+       * @event vaadin-overlay-open
+       * fired after the `vaadin-overlay` is opened.
+       */
       _openedChanged(opened) {
         if (opened) {
           this._placeholder = document.createComment('vaadin-overlay-placeholder');
@@ -186,16 +218,26 @@ This program is available under Apache License Version 2.0, available at https:/
           document.body.appendChild(this);
 
           document.addEventListener('click', this._boundOutsideClickListener, true);
-          document.addEventListener('keydown', this._boundEscapeListener);
+          document.addEventListener('keydown', this._boundKeydownListener);
 
           // Set body pointer-events to 'none' to disable mouse interactions with
           // other document nodes (combo-box is "modal")
           this._previousDocumentPointerEvents = document.body.style.pointerEvents;
           document.body.style.pointerEvents = 'none';
 
+          Polymer.Async.animationFrame.run(() => {
+            // Focus
+            //  - the overlay content by default
+            //  - or the first focusable element if focusTrap is true
+            this._setFocus(-1, 1);
+
+            const evt = new CustomEvent('vaadin-overlay-open', {bubbles: true});
+            this.dispatchEvent(evt);
+          });
+
         } else if (this._placeholder) {
           document.removeEventListener('click', this._boundOutsideClickListener, true);
-          document.removeEventListener('keydown', this._boundEspaceListener);
+          document.removeEventListener('keydown', this._boundKeydownListener);
 
           this._placeholder.parentNode.insertBefore(this, this._placeholder);
           this._processPendingMutationObserversFor(document.body);
@@ -220,6 +262,50 @@ This program is available under Apache License Version 2.0, available at https:/
 
       _contentChanged(content) {
         this.$.content.appendChild(content);
+      }
+
+      _setFocus(index, increment) {
+        if (!this.focusTrap) {
+          this._focusedElement = this.$.content;
+          return this.$.content.focus();
+        }
+
+        const focusableElements = this._getFocusableElements();
+        // search for visible elements and select the next possible match
+        for (let i = 0; i < focusableElements.length; i++) {
+          index = index + increment;
+
+          // rollover to first item
+          if (index === focusableElements.length) {
+            index = 0;
+
+          // go to last item
+          } else if (index === -1) {
+            index = focusableElements.length - 1;
+          }
+
+          // determine if element is visible
+          const el = focusableElements[index];
+          if (this._isVisible(el)) {
+            this._focusedElement = el;
+            return el.focus();
+          }
+        }
+      }
+
+      // borrowed from jqeury $(elem).is(':visible') implementation
+      _isVisible(elem) {
+        return elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length;
+      }
+
+      _getFocusableElements() {
+        const focusableElements = Array.from(this.$.content.querySelectorAll(
+          '[tabindex], button, input, select, textarea, object, iframe, label, a[href], area[href]'
+        ));
+
+        return focusableElements.filter((el) => {
+          return el.getAttribute('tabindex') !== '-1';
+        });
       }
 
       _processPendingMutationObserversFor(node) {

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -3,17 +3,17 @@ var argv = require('yargs').argv;
 module.exports = {
   registerHooks: function(context) {
     var saucelabsPlatforms = [
-      'OS X 10.11/iphone@10.0',
-      'OS X 10.11/ipad@10.0',
-      'Windows 10/microsoftedge@14',
+      'macOS 10.12/iphone@10.3',
+      'macOS 10.12/ipad@10.3',
+      'Windows 10/microsoftedge@15',
       'Windows 10/internet explorer@11',
-      'OS X 10.11/safari@10.0'
+      'macOS 10.12/safari@10.0'
     ];
 
     var cronPlatforms = [
       'Android/chrome',
-      'Windows 10/chrome@58',
-      'Windows 10/firefox@53'
+      'Windows 10/chrome@60',
+      'Windows 10/firefox@55'
     ];
 
     if (argv.env === 'saucelabs') {


### PR DESCRIPTION
In https://github.com/vaadin/vaadin-overlay/pull/13 we decided to move focus-trap functionality (which will be required by `vaadin-dialog`) to `vaadin-overlay`.

<img src="http://cf.chucklesnetwork.com/items/1/5/5/6/4/original/if-you-know-its-a-trap-and-go-in-it-is-it-still-a-trap.jpg" width="200">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/15)
<!-- Reviewable:end -->
