### PR TITLE
Support positioning and sizing with viewport constraints

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -80,6 +80,92 @@
         </script>
       </template>
     </demo-snippet>
+
+    <h3>Content Scrolling</h3>
+    <demo-snippet>
+      <template>
+        <vaadin-overlay id="overlay-scrollable"
+            style="
+              max-width: 300px;
+              max-height: 300px;
+            ">
+          <p>Lorem reiciendis doloribus dolor soluta laudantium. Ad delectus molestiae repudiandae repellendus perferendis? Commodi sequi rem animi eligendi eveniet provident dolore deserunt aperiam. Repellat quos architecto eos totam nulla consequuntur? Iste!</p>
+          <p>Lorem elit numquam commodi eligendi numquam fugiat? Mollitia culpa architecto ea eius non culpa ullam culpa itaque! Ex voluptates quisquam atque suscipit expedita. Libero quo accusamus corrupti atque dolore corrupti?</p>
+          <p>Elit ipsam error fuga voluptatum voluptates distinctio quod? Porro provident laborum et soluta enim nam blanditiis provident nulla eum eaque eius vel earum. Officiis quaerat voluptas quidem perspiciatis omnis ipsa.</p>
+          <p>Adipisicing nisi autem quod blanditiis officia blanditiis, cum. Ratione eius quia explicabo molestias iste maiores quas quod. Quia doloribus quis eius laboriosam cupiditate maxime non dignissimos adipisci unde exercitationem deserunt.</p>
+          <p>Lorem voluptate impedit qui tenetur molestiae nemo. Repellat sit repellat ratione distinctio laborum aut et numquam repellendus et dolorem aliquam molestiae voluptatum voluptas, possimus! Quaerat animi odit consequatur tempore ea.</p>
+        </vaadin-overlay>
+
+        <vaadin-button onclick="document.getElementById('overlay-scrollable').opened = true">
+          Show scrollable overlay
+        </vaadin-button>
+      </template>
+    </demo-snippet>
+
+    <h3>Positioning and Sizing With Inline Styles</h3>
+    <p>Default position and size: constrained to fit in the viewport, centering the content.</p>
+    <p>To customize, applying inline styles to the overlay in the following steps:</p>
+    <ol>
+      <li>
+        <p>
+          Customize constraints with <code>left</code>, <code>top</code>,
+          <code>right</code>, <code>bottom</code>, code in any combination. Default
+          values: <code>0</code> or small theme-defined offsets from the viewport.
+        </p>
+        <p>
+          <strong>Note:</strong> avoid setting <code>0</code> or
+          <code>auto</code> manually, leave unset to use a theme-defined
+          default viewport offset instead.
+        </p>
+        <p>
+          In addition, <code>max-width</code> and <code>max-height</code> are
+          also available, unset by default.
+        </p>
+      </li>
+      <li>
+        <p>
+          Align or stretch the content of the constrained overlay using
+          <code>align-items</code> and <code>justify-content</code>. Default
+          values are <code>center</code>.
+        </p>
+      </li>
+    </ol>
+    <demo-snippet>
+      <template>
+        <vaadin-overlay>I am next to the pointer</vaadin-overlay>
+        <vaadin-button id="button-overlay-pointer">Show the overlay next to click</vaadin-button>
+        <script>
+          document.getElementById('button-overlay-pointer').addEventListener('click', event => {
+            const overlay = event.target.previousElementSibling;
+            overlay.style = `
+              left: ${event.clientX}px;
+              top: ${event.clientY}px;
+              align-items: start;
+              justify-content: start;
+            `;
+            overlay.opened = true;
+          });
+        </script>
+
+        <vaadin-overlay>I am below the button</vaadin-overlay>
+        <vaadin-button id="button-overlay-below">Show the overlay below me</vaadin-button>
+        <script>
+          document.getElementById('button-overlay-below').addEventListener('click', event => {
+            const overlay = event.target.previousElementSibling;
+            const rect = event.target.getBoundingClientRect();
+            overlay.style = `
+              top: ${rect.bottom}px;
+              left: ${rect.left}px;
+              right: ${document.documentElement.clientWidth - rect.right}px;
+              align-items: stretch;
+              justify-content: start;
+            `;
+            overlay.opened = true;
+          });
+        </script>
+
+      </template>
+    </demo-snippet>
   </div>
 </body>
 </html>

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -2,6 +2,7 @@
   "globals": {
     "WCT": false,
     "describe": false,
+    "afterEach": false,
     "beforeEach": false,
     "fixture": false,
     "it": false,

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -31,11 +31,12 @@
   </test-fixture>
 
   <script>
-    const click = (el) => {
-      el.dispatchEvent(new CustomEvent('mousedown', {bubbles: true, composed: true}));
-      el.dispatchEvent(new CustomEvent('mouseup', {bubbles: true, composed: true}));
-      el.dispatchEvent(new CustomEvent('click', {bubbles: true, composed: true}));
-    };
+    const fire = (type, el) =>
+      el.dispatchEvent(new CustomEvent(type, {bubbles: true, cancelable: true, composed: true}));
+
+    const click = (el) => fire('click', el);
+    const mousedown = (el) => fire('mousedown', el);
+    const mouseup = (el) => fire('mouseup', el);
 
     describe('overlay', function() {
       var overlay, parent, content, backdrop, focusableElements;
@@ -48,6 +49,11 @@
         backdrop = overlay.$.backdrop;
         overlay._observer.flush();
         overlay.opened = true;
+      });
+
+      afterEach(function() {
+        // Avoid stacking up <vaadin-overlay> elements in the body.
+        overlay.opened = false;
       });
 
       it('should move under body when open', () => {
@@ -194,6 +200,40 @@
         expect(overlay.opened).to.be.true;
       });
 
+      describe('moving mouse pointer during click', () => {
+        it('should close if both mousedown and mouseup outside', () => {
+          mousedown(parent);
+          mouseup(parent);
+          click(parent);
+
+          expect(overlay.opened).to.be.false;
+        });
+
+        it('should not close if mousedown outside and mouseup inside', () => {
+          mousedown(parent);
+          mouseup(content);
+          click(content);
+
+          expect(overlay.opened).to.be.true;
+        });
+
+        it('should not close if mousedown inside and mouseup outside', () => {
+          mousedown(content);
+          mouseup(parent);
+          click(parent);
+
+          expect(overlay.opened).to.be.true;
+        });
+
+        it('should not close if both mousedown mouseup inside', () => {
+          mousedown(content);
+          mouseup(content);
+          click(content);
+
+          expect(overlay.opened).to.be.true;
+        });
+      });
+
       it('should not close on backdrop click if vaadin-overlay-outside-click event was canceled', () => {
         overlay.addEventListener('vaadin-overlay-outside-click', e => {
           e.preventDefault();
@@ -233,6 +273,65 @@
           }, 1);
         });
         click(parent);
+      });
+
+      it('should allow pointer events on the content while skipping on the host', () => {
+        expect(window.getComputedStyle(content).pointerEvents).to.equal('auto');
+        expect(window.getComputedStyle(overlay).pointerEvents).to.equal('none');
+      });
+
+      it('should have scrollable content', () => {
+        expect(window.getComputedStyle(content).overflow).to.equal('auto');
+      });
+
+      describe('position and sizing', () => {
+        it('should fit in the viewport by default', () => {
+          const rect = overlay.getBoundingClientRect();
+          expect(rect.left).to.be.gte(0);
+          expect(rect.top).to.be.gte(0);
+          expect(rect.right).to.be.lte(document.documentElement.clientWidth);
+          expect(rect.bottom).to.be.lte(document.documentElement.clientHeight);
+        });
+
+        it('should fit in viewport when huge content is used', () => {
+          content.lastElementChild.style = 'display: block; width: 2000px; height: 2000px;';
+
+          const rect = overlay.getBoundingClientRect();
+          expect(rect.left).to.be.gte(0);
+          expect(rect.top).to.be.gte(0);
+          expect(rect.right).to.be.lte(document.documentElement.clientWidth);
+          expect(rect.bottom).to.be.lte(document.documentElement.clientHeight);
+        });
+
+        it('should fit content in overlay', () => {
+          const overlayRect = overlay.getBoundingClientRect();
+          const contentRect = content.getBoundingClientRect();
+
+          expect(contentRect.left).to.be.gte(overlayRect.left);
+          expect(contentRect.top).to.be.gte(overlayRect.top);
+          expect(contentRect.right).to.be.lte(overlayRect.right);
+          expect(contentRect.bottom).to.be.lte(overlayRect.bottom);
+        });
+
+        it('should center content in overlay with flex by default', () => {
+          // The “default” fixture content is too large to test this
+          content.textContent = 'foo';
+
+          const overlayRect = overlay.getBoundingClientRect();
+          const contentRect = content.getBoundingClientRect();
+
+          const halfWidthDifference = (overlayRect.width - contentRect.width) / 2;
+          const halfHeightDifference = (overlayRect.height - contentRect.height) / 2;
+
+          // Should not stretch the content in the overlay
+          expect(halfWidthDifference).to.be.gte(0);
+          expect(halfHeightDifference).to.be.gte(0);
+
+          expect(contentRect.left - overlayRect.left).to.be.closeTo(halfWidthDifference, 1);
+          expect(overlayRect.right - contentRect.right).to.be.closeTo(halfWidthDifference, 1);
+          expect(contentRect.top - overlayRect.top).to.be.closeTo(halfHeightDifference, 1);
+          expect(overlayRect.bottom - contentRect.bottom).to.be.closeTo(halfHeightDifference, 1);
+        });
       });
     });
   </script>

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -12,10 +12,17 @@ This program is available under Apache License Version 2.0, available at https:/
 <dom-module id="vaadin-overlay-default-theme">
   <template>
     <style>
+      :host {
+        /* Make nice gaps inside viewport */
+        top: 8px;
+        right: 8px;
+        left: 8px;
+        bottom: 8px;
+      }
+
       [part="content"] {
         background: #fff;
-        -webkit-overflow-scrolling: touch;
-        overflow: auto;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
       }
     </style>
   </template>
@@ -27,10 +34,33 @@ This program is available under Apache License Version 2.0, available at https:/
       :host {
         z-index: 200;
         position: fixed;
+
+        /*
+          Despite of what the names say, <vaadin-overlay> is just a container
+          for position/sizing/alignment. The actual overlay is the content part.
+        */
+
+        /*
+          Default position constraints: the entire viewport. Note: themes can
+          override this to introduce gaps between the overlay and the viewport.
+        */
         top: 0;
+        right: 0;
+        bottom: 0;
         left: 0;
-        pointer-events: auto;
-        overflow: hidden;
+
+        /* Use flexbox alignment for the content part. */
+        display: flex;
+        flex-direction: column; /* makes dropdowns sizing easier */
+        /* Align to center by default. */
+        align-items: center;
+        justify-content: center;
+
+        /* Allow centering when max-width/max-height applies. */
+        margin: auto;
+
+        /* The host is not clickable, only the content is. */
+        pointer-events: none;
       }
 
       :host(:not([opened])) {
@@ -38,7 +68,10 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       [part="content"] {
-        max-height: 100%;
+        -webkit-overflow-scrolling: touch;
+        overflow: auto;
+        pointer-events: auto;
+        max-width: 100%; /* prevents overflowing the host in MSIE 11 */
       }
 
       [part="backdrop"] {
@@ -50,6 +83,7 @@ This program is available under Apache License Version 2.0, available at https:/
         left: 0;
         bottom: 0;
         right: 0;
+        pointer-events: auto;
       }
     </style>
 
@@ -208,7 +242,10 @@ This program is available under Apache License Version 2.0, available at https:/
        * fired before the `vaadin-overlay` will be closed on outside click. If canceled the closing of the overlay is canceled as well.
        */
       _outsideClickListener(event) {
-        if (this._mouseDownInside || this._mouseUpInside) {
+        if (event.composedPath().indexOf(this.$.content) !== -1 ||
+            this._mouseDownInside || this._mouseUpInside) {
+          this._mouseDownInside = false;
+          this._mouseUpInside = false;
           return;
         }
 


### PR DESCRIPTION
Fixes #22

Idea in brief:

- Use <vaadin-overlay> hosting element as a positioning / sizing /
  alignment constrained container only.
- Use flexbox to align and / or stretch the content part inside
  the constrained <vaadin-overlay> host element.
- Use the content part as the actual overlay. Themes should define
  borders / shadows / backgrounds on the content part.

This requires several changes beyond this repo, PRs will follow shortly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/25)
<!-- Reviewable:end -->
