### PR TITLE
Add separate scrollable overlay part, use content part just for paddings

### DIFF
--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -52,11 +52,12 @@
     const mouseup = (el) => fire('mouseup', el);
 
     describe('overlay', function() {
-      var overlay, parent, content, backdrop, focusableElements;
+      var overlay, parent, overlayPart, content, backdrop, focusableElements;
 
       beforeEach(function() {
         parent = fixture('default').children[0];
         overlay = parent.children[0];
+        overlayPart = overlay.$.overlay;
         content = overlay.$.content;
         focusableElements = overlay._getFocusableElements();
         backdrop = overlay.$.backdrop;
@@ -134,14 +135,15 @@
           beforeEach(function() {
             parent = fixture('empty').children[0];
             overlay = parent.children[0];
+            overlayPart = overlay.$.overlay;
             content = overlay.$.content;
             overlay._observer.flush();
             overlay.opened = true;
           });
 
-          it('should focus the content when focusTrap = true', (done) => {
+          it('should focus the overlayPart when focusTrap = true', (done) => {
             overlay.addEventListener('vaadin-overlay-open', () => {
-              expect(overlay._focusedElement).to.eql(content);
+              expect(overlay._focusedElement).to.eql(overlayPart);
               done();
             });
           });
@@ -184,7 +186,7 @@
       });
 
       it('should not close on inside click', () => {
-        click(content);
+        click(overlayPart);
 
         expect(overlay.opened).to.be.true;
       });
@@ -212,7 +214,7 @@
         };
 
         overlay.addEventListener('vaadin-overlay-outside-click', outsideClickHandler, false);
-        click(content);
+        click(overlayPart);
         overlay.removeEventListener('vaadin-overlay-outside-click', outsideClickHandler, false);
       });
 
@@ -242,14 +244,14 @@
 
         it('should not close if mousedown outside and mouseup inside', () => {
           mousedown(parent);
-          mouseup(content);
-          click(content);
+          mouseup(overlayPart);
+          click(overlayPart);
 
           expect(overlay.opened).to.be.true;
         });
 
         it('should not close if mousedown inside and mouseup outside', () => {
-          mousedown(content);
+          mousedown(overlayPart);
           mouseup(parent);
           click(parent);
 
@@ -257,9 +259,9 @@
         });
 
         it('should not close if both mousedown mouseup inside', () => {
-          mousedown(content);
-          mouseup(content);
-          click(content);
+          mousedown(overlayPart);
+          mouseup(overlayPart);
+          click(overlayPart);
 
           expect(overlay.opened).to.be.true;
         });
@@ -272,7 +274,7 @@
 
         it('should close on outside click after mouseup inside', () => {
           // assume the overlay was opened on contextmenu event
-          mouseup(content);
+          mouseup(overlayPart);
 
           mousedown(parent);
           mouseup(parent);
@@ -294,11 +296,11 @@
         });
 
         it('should not close on inside click after mouseup inside', () => {
-          mouseup(content);
+          mouseup(overlayPart);
 
-          mousedown(content);
-          mouseup(content);
-          click(content);
+          mousedown(overlayPart);
+          mouseup(overlayPart);
+          click(overlayPart);
 
           expect(overlay.opened).to.be.true;
         });
@@ -306,9 +308,9 @@
         it('should not close on outside click after mouseup outside', () => {
           mouseup(parent);
 
-          mousedown(content);
-          mouseup(content);
-          click(content);
+          mousedown(overlayPart);
+          mouseup(overlayPart);
+          click(overlayPart);
 
           expect(overlay.opened).to.be.true;
         });
@@ -369,13 +371,13 @@
         Vaadin.OverlayElement.prototype.addEventListener.restore();
       });
 
-      it('should allow pointer events on the content while skipping on the host', () => {
-        expect(window.getComputedStyle(content).pointerEvents).to.equal('auto');
+      it('should allow pointer events on the overlayPart while skipping on the host', () => {
+        expect(window.getComputedStyle(overlayPart).pointerEvents).to.equal('auto');
         expect(window.getComputedStyle(overlay).pointerEvents).to.equal('none');
       });
 
-      it('should have scrollable content', () => {
-        expect(window.getComputedStyle(content).overflow).to.equal('auto');
+      it('should have scrollable overlayPart', () => {
+        expect(window.getComputedStyle(overlayPart).overflow).to.equal('auto');
       });
 
       describe('position and sizing', () => {
@@ -397,34 +399,34 @@
           expect(rect.bottom).to.be.lte(document.documentElement.clientHeight);
         });
 
-        it('should fit content in overlay', () => {
+        it('should fit overlayPart in overlay', () => {
           const overlayRect = overlay.getBoundingClientRect();
-          const contentRect = content.getBoundingClientRect();
+          const overlayPartRect = overlayPart.getBoundingClientRect();
 
-          expect(contentRect.left).to.be.gte(overlayRect.left);
-          expect(contentRect.top).to.be.gte(overlayRect.top);
-          expect(contentRect.right).to.be.lte(overlayRect.right);
-          expect(contentRect.bottom).to.be.lte(overlayRect.bottom);
+          expect(overlayPartRect.left).to.be.gte(overlayRect.left);
+          expect(overlayPartRect.top).to.be.gte(overlayRect.top);
+          expect(overlayPartRect.right).to.be.lte(overlayRect.right);
+          expect(overlayPartRect.bottom).to.be.lte(overlayRect.bottom);
         });
 
-        it('should center content in overlay with flex by default', () => {
+        it('should center overlayPart in overlay with flex by default', () => {
           // The “default” fixture content is too large to test this
           content.textContent = 'foo';
 
           const overlayRect = overlay.getBoundingClientRect();
-          const contentRect = content.getBoundingClientRect();
+          const overlayPartRect = overlayPart.getBoundingClientRect();
 
-          const halfWidthDifference = (overlayRect.width - contentRect.width) / 2;
-          const halfHeightDifference = (overlayRect.height - contentRect.height) / 2;
+          const halfWidthDifference = (overlayRect.width - overlayPartRect.width) / 2;
+          const halfHeightDifference = (overlayRect.height - overlayPartRect.height) / 2;
 
-          // Should not stretch the content in the overlay
+          // Should not stretch the overlayPart in the overlay
           expect(halfWidthDifference).to.be.gte(0);
           expect(halfHeightDifference).to.be.gte(0);
 
-          expect(contentRect.left - overlayRect.left).to.be.closeTo(halfWidthDifference, 1);
-          expect(overlayRect.right - contentRect.right).to.be.closeTo(halfWidthDifference, 1);
-          expect(contentRect.top - overlayRect.top).to.be.closeTo(halfHeightDifference, 1);
-          expect(overlayRect.bottom - contentRect.bottom).to.be.closeTo(halfHeightDifference, 1);
+          expect(overlayPartRect.left - overlayRect.left).to.be.closeTo(halfWidthDifference, 1);
+          expect(overlayRect.right - overlayPartRect.right).to.be.closeTo(halfWidthDifference, 1);
+          expect(overlayPartRect.top - overlayRect.top).to.be.closeTo(halfHeightDifference, 1);
+          expect(overlayRect.bottom - overlayPartRect.bottom).to.be.closeTo(halfHeightDifference, 1);
         });
       });
     });

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -20,7 +20,7 @@ This program is available under Apache License Version 2.0, available at https:/
         bottom: 8px;
       }
 
-      [part="content"] {
+      [part="overlay"] {
         background: #fff;
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
       }
@@ -37,7 +37,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /*
           Despite of what the names say, <vaadin-overlay> is just a container
-          for position/sizing/alignment. The actual overlay is the content part.
+          for position/sizing/alignment. The actual overlay is the overlay part.
         */
 
         /*
@@ -49,7 +49,7 @@ This program is available under Apache License Version 2.0, available at https:/
         bottom: 0;
         left: 0;
 
-        /* Use flexbox alignment for the content part. */
+        /* Use flexbox alignment for the overlay part. */
         display: flex;
         flex-direction: column; /* makes dropdowns sizing easier */
         /* Align to center by default. */
@@ -59,7 +59,7 @@ This program is available under Apache License Version 2.0, available at https:/
         /* Allow centering when max-width/max-height applies. */
         margin: auto;
 
-        /* The host is not clickable, only the content is. */
+        /* The host is not clickable, only the overlay part is. */
         pointer-events: none;
 
         /* Remove tap highlight on touch devices. */
@@ -70,7 +70,7 @@ This program is available under Apache License Version 2.0, available at https:/
         display: none !important;
       }
 
-      [part="content"] {
+      [part="overlay"] {
         -webkit-overflow-scrolling: touch;
         overflow: auto;
         pointer-events: auto;
@@ -94,8 +94,10 @@ This program is available under Apache License Version 2.0, available at https:/
     <div id="backdrop" part="backdrop" hidden$="{{!withBackdrop}}">
 
     </div>
-    <div part="content" id="content">
-      <slot id="slot"></slot>
+    <div part="overlay" id="overlay">
+      <div part="content" id="content">
+        <slot id="slot"></slot>
+      </div>
     </div>
   </template>
 </dom-module>
@@ -247,11 +249,11 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _mouseDownListener(event) {
-        this._mouseDownInside = event.composedPath().indexOf(this.$.content) >= 0;
+        this._mouseDownInside = event.composedPath().indexOf(this.$.overlay) >= 0;
       }
 
       _mouseUpListener(event) {
-        this._mouseUpInside = event.composedPath().indexOf(this.$.content) >= 0;
+        this._mouseUpInside = event.composedPath().indexOf(this.$.overlay) >= 0;
       }
 
       /**
@@ -263,7 +265,7 @@ This program is available under Apache License Version 2.0, available at https:/
        * fired before the `vaadin-overlay` will be closed on outside click. If canceled the closing of the overlay is canceled as well.
        */
       _outsideClickListener(event) {
-        if (event.composedPath().indexOf(this.$.content) !== -1 ||
+        if (event.composedPath().indexOf(this.$.overlay) !== -1 ||
             this._mouseDownInside || this._mouseUpInside) {
           this._mouseDownInside = false;
           this._mouseUpInside = false;
@@ -400,8 +402,8 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         // fallback if there are no focusable elements
-        this._focusedElement = this.$.content;
-        this.$.content.focus();
+        this._focusedElement = this.$.overlay;
+        this.$.overlay.focus();
       }
 
       // borrowed from jqeury $(elem).is(':visible') implementation


### PR DESCRIPTION
Fixes #29

Considerations for choosing this way:

- More sanity to parts naming. Themes should style [part~="overlay"] with
  backgrounds, borders and shadows, and [part~="content"] for paddings
  inside the scrollable overlay area.
- Outside click detection is based on the scrollable overlay part,
  so that clicking the scrollbar is considered “inside”.
- Default focusTrap target is also the overlay part, not the content.
  This does not really matter now, because neither of them is actually
  focusable, but if some day there would be focus, it should be on the
  scrollable element, it’s better for accessibility reasons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/31)
<!-- Reviewable:end -->
