### PR TITLE
Use e.key instead of deprecated e.keyCode

### DIFF
--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -126,15 +126,15 @@
             // TAB
             for (let i = 0; i < focusableElements.length; i++) {
               expect(overlay._focusedElement).to.eql(focusableElements[i]);
-              MockInteractions.pressAndReleaseKeyOn(document.body, 9);
+              MockInteractions.pressAndReleaseKeyOn(document.body, 9, [], 'Tab');
             }
             expect(overlay._focusedElement).to.eql(focusableElements[0]);
 
             // SHIFT+TAB
-            MockInteractions.pressAndReleaseKeyOn(document.body, 9, 'shift');
+            MockInteractions.pressAndReleaseKeyOn(document.body, 9, 'shift', 'Tab');
             for (let i = focusableElements.length - 1; i >= 0; i--) {
               expect(overlay._focusedElement).to.eql(focusableElements[i]);
-              MockInteractions.pressAndReleaseKeyOn(document.body, 9, 'shift');
+              MockInteractions.pressAndReleaseKeyOn(document.body, 9, 'shift', 'Tab');
             }
             expect(overlay._focusedElement).to.eql(focusableElements[focusableElements.length - 1]);
             done();
@@ -161,7 +161,7 @@
       });
 
       it('should close on esc', () => {
-        MockInteractions.pressAndReleaseKeyOn(document.body, 27);
+        MockInteractions.pressAndReleaseKeyOn(document.body, 27, [], 'Escape');
 
         expect(overlay.opened).to.be.false;
       });
@@ -179,8 +179,8 @@
 
         overlay.addEventListener('vaadin-overlay-escape-press', doneHandler, false);
 
-        MockInteractions.pressAndReleaseKeyOn(document.body, 27);
-        MockInteractions.pressAndReleaseKeyOn(document.body, 13);
+        MockInteractions.pressAndReleaseKeyOn(document.body, 27, [], 'Escape');
+        MockInteractions.pressAndReleaseKeyOn(document.body, 13, [], 'Enter');
 
         overlay.removeEventListener('vaadin-overlay-escape-press', doneHandler, false);
       });
@@ -190,7 +190,7 @@
           e.preventDefault();
         });
 
-        MockInteractions.pressAndReleaseKeyOn(document.body, 27);
+        MockInteractions.pressAndReleaseKeyOn(document.body, 27, [], 'Escape');
 
         expect(overlay.opened).to.be.true;
       });

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -307,7 +307,7 @@ This program is available under Apache License Version 2.0, available at https:/
        */
       _keydownListener(event) {
         // TAB
-        if (event.keyCode === 9 && this.focusTrap) {
+        if (event.key === 'Tab' && this.focusTrap) {
           const focusableElements = this._getFocusableElements();
           const focusedElementIndex = focusableElements.indexOf(this._focusedElement);
 
@@ -323,7 +323,7 @@ This program is available under Apache License Version 2.0, available at https:/
           event.preventDefault();
 
         // ESC
-        } else if (event.keyCode === 27) {
+        } else if (event.key === 'Escape' || event.key === 'Esc') {
           const evt = new CustomEvent('vaadin-overlay-escape-press', {bubbles: true, cancelable: true, detail: {sourceEvent: event}});
           this.dispatchEvent(evt);
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode

![](https://i.imgur.com/9Yg6zav.png)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/39)
<!-- Reviewable:end -->
