### PR TITLE
replace `polymer test` by `wct` in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ install:
 before_script:
   - gulp lint
   - polymer lint --rules polymer-2 --input *.html
-  - xvfb-run -s '-screen 0 1024x768x24' polymer test
+  - xvfb-run -s '-screen 0 1024x768x24' wct
 
 script:
   - if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" && "$TRAVIS_BRANCH" != quick/* ]]; then
-      xvfb-run -s '-screen 0 1024x768x24' polymer test --env saucelabs;
+      xvfb-run -s '-screen 0 1024x768x24' wct --env saucelabs;
     fi
   - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-      xvfb-run -s '-screen 0 1024x768x24' polymer test --env saucelabs-cron;
+      xvfb-run -s '-screen 0 1024x768x24' wct --env saucelabs-cron;
     fi


### PR DESCRIPTION
After updating polymer-cli, the build never ends, e.g `polymer test -l chrome`,  otherwise running `wct -l chrome` it works.

Downgrading polymer-cli and wct does not fix the problem, seems that the issue is in a 3rd party dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/40)
<!-- Reviewable:end -->
