### PR TITLE
Ignore outside click events and escape when recent overlays opened exist

### DIFF
--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -158,6 +158,35 @@
             });
           });
         });
+
+        describe('stacking overays', function() {
+          let overlay1, overlay2;
+
+          beforeEach(function() {
+            overlay1 = overlay;
+            parent = fixture('empty').children[0];
+            overlay2 = parent.children[0];
+          });
+
+          it('should be the last when only one overlay is opened', () => {
+            overlay1.opened = true;
+            expect(overlay1.last).to.be.true;
+          });
+
+          it('should not be the last when another overlay is opened after this', () => {
+            overlay1.opened = true;
+            overlay2.opened = true;
+            expect(overlay1.last).not.to.be.true;
+            expect(overlay2.last).to.be.true;
+          });
+
+          it('should become last when the last overlay is closed', () => {
+            overlay1.opened = true;
+            overlay2.opened = true;
+            overlay2.opened = false;
+            expect(overlay1.last).to.be.true;
+          });
+        });
       });
 
       it('should close on esc', () => {

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -169,21 +169,21 @@
 
           it('should be the last when only one overlay is opened', () => {
             overlay1.opened = true;
-            expect(overlay1.last).to.be.true;
+            expect(overlay1._last).to.be.true;
           });
 
           it('should not be the last when another overlay is opened after this', () => {
             overlay1.opened = true;
             overlay2.opened = true;
-            expect(overlay1.last).not.to.be.true;
-            expect(overlay2.last).to.be.true;
+            expect(overlay1._last).not.to.be.true;
+            expect(overlay2._last).to.be.true;
           });
 
           it('should become last when the last overlay is closed', () => {
             overlay1.opened = true;
             overlay2.opened = true;
             overlay2.opened = false;
-            expect(overlay1.last).to.be.true;
+            expect(overlay1._last).to.be.true;
           });
 
           it('should fire the vaadin-overlay-escape-press if it is the only overlay opened', () => {

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -159,13 +159,12 @@
           });
         });
 
-        describe('stacking overays', function() {
+        describe('multiple overlays', function() {
           let overlay1, overlay2;
 
           beforeEach(function() {
             overlay1 = overlay;
-            parent = fixture('empty').children[0];
-            overlay2 = parent.children[0];
+            overlay2 = fixture('empty').children[0].children[0];
           });
 
           it('should be the last when only one overlay is opened', () => {
@@ -185,6 +184,40 @@
             overlay2.opened = true;
             overlay2.opened = false;
             expect(overlay1.last).to.be.true;
+          });
+
+          it('should fire the vaadin-overlay-escape-press if it is the only overlay opened', () => {
+            var spy = sinon.spy();
+            overlay1.addEventListener('vaadin-overlay-escape-press', spy);
+            overlay1.opened = true;
+            MockInteractions.pressAndReleaseKeyOn(document.body, 27, [], 'Escape');
+            expect(spy).to.be.called.once;
+          });
+
+          it('should not fire the vaadin-overlay-escape-press if there is a recent overlay opened', () => {
+            var spy = sinon.spy();
+            overlay1.addEventListener('vaadin-overlay-escape-press', spy);
+            overlay1.opened = true;
+            overlay2.opened = true;
+            MockInteractions.pressAndReleaseKeyOn(document.body, 27, [], 'Escape');
+            expect(spy).not.to.be.called;
+          });
+
+          it('should fire the vaadin-overlay-outside-click if it is the only overlay opened', () => {
+            var spy = sinon.spy();
+            overlay1.addEventListener('vaadin-overlay-outside-click', spy);
+            overlay1.opened = true;
+            click(parent);
+            expect(spy).to.be.called.once;
+          });
+
+          it('should not fire the vaadin-overlay-outside-click if there is a recent overlay opened', () => {
+            var spy = sinon.spy();
+            overlay1.addEventListener('vaadin-overlay-outside-click', spy);
+            overlay1.opened = true;
+            overlay2.opened = true;
+            click(parent);
+            expect(spy).not.to.be.called;
           });
         });
       });

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -359,7 +359,6 @@ This program is available under Apache License Version 2.0, available at https:/
           if (!this.modeless) {
             this._enterModalState();
           }
-
         } else {
           if (this._placeholder) {
             this._placeholder.parentNode.insertBefore(this, this._placeholder);
@@ -368,6 +367,13 @@ This program is available under Apache License Version 2.0, available at https:/
           }
           this._exitModalState();
         }
+      }
+
+      /**
+       * returns true if this is the last in the opened overlay stack
+       */
+      get last() {
+        return this == Array.from(document.body.children).filter(e => e instanceof Vaadin.OverlayElement).pop();
       }
 
       _modelessChanged(modeless) {

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -287,10 +287,13 @@ This program is available under Apache License Version 2.0, available at https:/
        * fired before the `vaadin-overlay` will be closed on outside click. If canceled the closing of the overlay is canceled as well.
        */
       _outsideClickListener(event) {
-        if (!this.last || event.composedPath().indexOf(this.$.overlay) !== -1 ||
+        if (event.composedPath().indexOf(this.$.overlay) !== -1 ||
             this._mouseDownInside || this._mouseUpInside) {
           this._mouseDownInside = false;
           this._mouseUpInside = false;
+          return;
+        }
+        if (!this._last) {
           return;
         }
 
@@ -307,7 +310,7 @@ This program is available under Apache License Version 2.0, available at https:/
        * fired before the `vaadin-overlay` will be closed on ESC button press. If canceled the closing of the overlay is canceled as well.
        */
       _keydownListener(event) {
-        if (!this.last) {
+        if (!this._last) {
           return;
         }
 
@@ -374,9 +377,9 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       /**
-       * returns true if this is the last in the opened overlay stack
+       * returns true if this is the last one in the opened overlays stack
        */
-      get last() {
+      get _last() {
         return this == Array.from(document.body.children).filter(e => e instanceof Vaadin.OverlayElement).pop();
       }
 

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -287,7 +287,7 @@ This program is available under Apache License Version 2.0, available at https:/
        * fired before the `vaadin-overlay` will be closed on outside click. If canceled the closing of the overlay is canceled as well.
        */
       _outsideClickListener(event) {
-        if (event.composedPath().indexOf(this.$.overlay) !== -1 ||
+        if (!this.last || event.composedPath().indexOf(this.$.overlay) !== -1 ||
             this._mouseDownInside || this._mouseUpInside) {
           this._mouseDownInside = false;
           this._mouseUpInside = false;
@@ -307,6 +307,10 @@ This program is available under Apache License Version 2.0, available at https:/
        * fired before the `vaadin-overlay` will be closed on ESC button press. If canceled the closing of the overlay is canceled as well.
        */
       _keydownListener(event) {
+        if (!this.last) {
+          return;
+        }
+
         // TAB
         if (event.key === 'Tab' && this.focusTrap) {
           const focusableElements = this._getFocusableElements();


### PR DESCRIPTION
Fixes #43

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/44)
<!-- Reviewable:end -->
