### PR TITLE
Switch from idlePeriod to afterNextRender

### DIFF
--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -392,7 +392,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.parentNode.insertBefore(this._placeholder, this);
           document.body.appendChild(this);
 
-          Polymer.Async.idlePeriod.run(() => {
+          Polymer.RenderStatus.afterNextRender(this, () => {
             if (this.focusTrap) {
               // Focus
               //  - the overlay content by default

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -6,6 +6,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
 <link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="../polymer/lib/utils/templatize.html">
+<link rel="import" href="../polymer/lib/utils/render-status.html">
 <link rel="import" href="../polymer/lib/utils/flattened-nodes-observer.html">
 <link rel="import" href="../vaadin-themable-mixin/vaadin-themable-mixin.html">
 


### PR DESCRIPTION
Switch from `idlePeriod` to `afterNextRender` to fix rendering delay in `vaadin-date-picker`.
Connected to https://github.com/vaadin/vaadin-date-picker/pull/482

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/52)
<!-- Reviewable:end -->
