### PR TITLE
visit shadow elements when computing focusableElements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,6 +33,13 @@
     "iron-demo-helpers": "^2.0.0",
     "iron-test-helpers": "^2.0.0",
     "vaadin-button": "^1.0.0",
-    "web-component-tester": "^6.0.0"
+    "web-component-tester": "^6.0.0",
+    "vaadin-dialog": "^1.0.1",
+    "vaadin-context-menu": "^2.0.0",
+    "vaadin-dropdown-menu": "^1.0.0-alpha3",
+    "vaadin-combo-box": "^3.0.2",
+    "vaadin-date-picker": "^2.0.7",
+    "vaadin-list-box": "^1.0.0-alpha3",
+    "vaadin-item": "^1.0.0-alpha7"
   }
 }

--- a/demo/advanced.html
+++ b/demo/advanced.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+  <title>vaadin-overlay Basic Examples</title>
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <link rel="import" href="../../vaadin-text-field/vaadin-text-field.html">
+  <link rel="import" href="../../vaadin-text-field/vaadin-password-field.html">
+  <link rel="import" href="../../vaadin-text-field/vaadin-textarea.html">
+  <link rel="import" href="../../vaadin-date-picker/vaadin-date-picker.html">
+  <link rel="import" href="../../vaadin-combo-box/vaadin-combo-box.html">
+  <link rel="import" href="../../vaadin-context-menu/vaadin-context-menu.html">
+  <link rel="import" href="../../vaadin-dropdown-menu/vaadin-dropdown-menu.html">
+  <link rel="import" href="../../vaadin-list-box/vaadin-list-box.html">
+  <link rel="import" href="../../vaadin-item/vaadin-item.html">
+  <link rel="import" href="../../vaadin-dialog/vaadin-dialog.html">
+  <link rel="import" href="../../vaadin-button/vaadin-button.html">
+  <link rel="import" href="common.html">
+</head>
+
+<body unresolved>
+  <div class="vertical-section-container centered">
+
+    <demo-navigation></demo-navigation>
+    <h3>Form in Dialog</h3>
+    <demo-snippet id='overlay-advanced-demos-form-dialog'>
+      <template>
+
+        <dom-module id="my-form-element">
+          <template preserve-content>
+            <vaadin-text-field tabindex="4" label="Text Field" placeholder="TabIndex 4"></vaadin-text-field>
+            <vaadin-password-field tabindex="3"  label="Password Field" placeholder="TabIndex 3"></vaadin-password-field>
+            <vaadin-date-picker tabindex="2" label="Date Picker" placeholder="TabIndex 2"></vaadin-date-picker>
+            <br/>
+            <vaadin-combo-box tabindex="2" label="Combo Box" placeholder="TabIndex 2" items="[1, 2, 3]"></vaadin-combo-box>
+            <vaadin-dropdown-menu tabindex="1" label="Dropdown Menu" placeholder="TabIndex 1">
+              <template>
+                <vaadin-list-box>
+                  <vaadin-item>Item 1</vaadin-item>
+                  <vaadin-item>Item 2</vaadin-item>
+                  <vaadin-item>Item 3</vaadin-item>
+                </vaadin-list-box>
+              </template>
+            </vaadin-dropdown-menu>
+            <vaadin-text-field label="Text Field" placeholder="TabIndex 0"></vaadin-text-field>
+            <br/>
+            <vaadin-context-menu selector="vaadin-button" open-on="click" close-on="none">
+              <template>
+                <vaadin-list-box>
+                  <vaadin-item>Item 1</vaadin-item>
+                  <vaadin-item>Item 2</vaadin-item>
+                  <vaadin-item>Item 3</vaadin-item>
+                </vaadin-list-box>
+              </template>
+              <vaadin-button>Context Menu, TabIndex 0</vaadin-button>
+            </vaadin-context-menu>
+
+            <vaadin-button>NOP, TabIndex 0</vaadin-button>
+            <vaadin-button tabindex="1">NOP, TabIndex 1</vaadin-button>
+          </template>
+          <script>
+            class MyFormElement extends Polymer.Element {
+              static get is() {
+                return 'my-form-element';
+              }
+            }
+            window.customElements.define(MyFormElement.is, MyFormElement);
+          </script>
+        </dom-module>
+
+        <vaadin-dialog id="dialog">
+          <template>
+            <my-form-element></my-form-element>
+          </template>
+        </vaadin-dialog>
+        <vaadin-button id="button">Show Form Dialog</vaadin-button>
+
+        <script>
+          window.addEventListener('WebComponentsReady', () => {
+            const dlg = document.querySelector('#dialog');
+            const btn = document.querySelector('#button');
+            btn.addEventListener('click', () => dlg.opened = true);
+          });
+        </script>
+
+        <my-demo2></my-demo2>
+      </template>
+    </demo-snippet>
+
+
+    <h3>Nested Dialog</h3>
+    <demo-snippet id='overlay-advanced-demos-nested-dialog'>
+      <template>
+        <dom-module id="my-demo1">
+          <template preserve-content>
+            <vaadin-dialog id="dialog1">
+              <template>
+                <div>You can close this dialog by pressing 'Close' button</div>
+                <div>By pressing the other one, second dialog will be opened</div>
+                <br>
+                <vaadin-button on-click="_close1">Close</vaadin-button>
+                <vaadin-button on-click="_open2">Open second</vaadin-button>
+              </template>
+            </vaadin-dialog>
+
+            <vaadin-dialog id="dialog2">
+              <template>
+                <div>Close this dialog by pressing 'Close'</div>
+                <div>Use the second button to close both dialogs</div>
+                <br>
+                <vaadin-button on-click="_close2">Cancel</vaadin-button>
+                <vaadin-button on-click="_closeAll">Close All</vaadin-button>
+              </template>
+            </vaadin-dialog>
+
+            <vaadin-button on-click="_open1">Show dialog</vaadin-button>
+          </template>
+
+          <script>
+            class MyDemo1 extends Polymer.Element {
+              static get is() {
+                return 'my-demo1';
+              }
+              _open1() {
+                this.$.dialog1.opened = true;
+              }
+              _open2() {
+                this.$.dialog2.opened = true;
+              }
+              _close1() {
+                this.$.dialog1.opened = false;
+              }
+              _close2() {
+                this.$.dialog2.opened = false;
+              }
+              _closeAll() {
+                this.$.dialog2.opened = false;
+                this.$.dialog1.opened = false;
+              }
+            }
+            window.customElements.define(MyDemo1.is, MyDemo1);
+          </script>
+        </dom-module>
+        <my-demo1></my-demo1>
+      </template>
+    </demo-snippet>
+  </div>
+</body>
+</html>

--- a/demo/common.html
+++ b/demo/common.html
@@ -11,7 +11,8 @@
 <!-- Menu Items -->
 <script>
   window.demos = [
-    {name: 'index', title: 'Basic Examples'}
+    {name: 'index', title: 'Basic Examples'},
+    {name: 'advanced', title: 'Advanced Demos'}
   ];
 </script>
 <link rel="import" href="../../elements-demo-resources/demo-navigation.html">

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -132,7 +132,7 @@
           overlay.focusTrap = true;
 
           // focusableElements changes when setting focus trap property
-          focusableElements = overlay._getFocusableElements()
+          focusableElements = overlay._getFocusableElements();
           const testelement = content.querySelector('my-test-element');
 
           expect(focusableElements.length).to.eql(5);

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -10,6 +10,29 @@
 </head>
 
 <body>
+  <dom-module id="my-test-element">
+    <template>
+      <button id="elem-0a">[0] button</button>
+      <button id="elem--1" tabindex="-1">[-1] button</button>
+      <select id="elem-2" tabindex="2"><option>[2] option</option></select>
+      <div>nop</div>
+      <textarea id="elem-1" tabindex="1">[1] textarea</textarea>
+      <input id="elem-0b" type="text" value="[0]" />
+      <vaadin-button id="elem-0c">[0] vaadin-button</vaadin-button>
+    </template>
+
+    <script>
+      window.addEventListener('WebComponentsReady', () => {
+        class MyTestElement extends Polymer.Element {
+          static get is() {
+            return 'my-test-element';
+          }
+        }
+        window.customElements.define(MyTestElement.is, MyTestElement);
+      });
+    </script>
+  </dom-module>
+
   <test-fixture id="default">
     <template>
       <div>
@@ -17,12 +40,7 @@
           <vaadin-overlay>
             <template>
               content
-              <button>native button</button>
-              <button tabindex="-1">button with tabindex="-1"</button>
-              <select tabindex="2"></select>
-              <textarea tabindex="1"></textarea>
-              <input type="text">
-              <vaadin-button>vaadin-button</vaadin-button>
+              <my-test-element id='testelement'></my-test-element>
             </template>
           </vaadin-overlay>
         </div>
@@ -55,7 +73,7 @@
       var overlay, parent, overlayPart, content, backdrop, focusableElements;
 
       beforeEach(function() {
-        parent = fixture('default').children[0];
+        parent = fixture('default').querySelector('#parent');
         overlay = parent.children[0];
         overlayPart = overlay.$.overlay;
         content = overlay.$.content;
@@ -112,12 +130,17 @@
 
         it('should properly detect focusable elements inside the content', () => {
           overlay.focusTrap = true;
+
+          // focusableElements changes when setting focus trap property
+          focusableElements = overlay._getFocusableElements()
+          const testelement = content.querySelector('my-test-element');
+
           expect(focusableElements.length).to.eql(5);
-          expect(focusableElements[0]).to.eql(overlay.$.content.querySelector('textarea'));
-          expect(focusableElements[1]).to.eql(overlay.$.content.querySelector('select'));
-          expect(focusableElements[2]).to.eql(overlay.$.content.querySelector('button'));
-          expect(focusableElements[3]).to.eql(overlay.$.content.querySelector('input'));
-          expect(focusableElements[4]).to.eql(overlay.$.content.querySelector('vaadin-button'));
+          expect(focusableElements[0]).to.eql(testelement.$['elem-1']);
+          expect(focusableElements[1]).to.eql(testelement.$['elem-2']);
+          expect(focusableElements[2]).to.eql(testelement.$['elem-0a']);
+          expect(focusableElements[3]).to.eql(testelement.$['elem-0b']);
+          expect(focusableElements[4]).to.eql(testelement.$['elem-0c']);
         });
 
         it('should focus focusable elements inside the content when focusTrap = true', (done) => {

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -208,7 +208,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       static get observers() {
-        return ['_openedChanged(opened)', '_templateChanged(template)', '_contentChanged(content)'];
+        return ['_openedChanged(opened)', '_focusTrapChanged(focusTrap)', '_templateChanged(template)', '_contentChanged(content)'];
       }
 
       constructor() {
@@ -476,6 +476,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _contentChanged(content) {
+        delete this._focusableElements;
         this.$.content.appendChild(content);
       }
 
@@ -501,7 +502,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
           // determine if element is visible
           const el = focusableElements[index];
-          if (this._isVisible(el)) {
+          if (!el.disabled && this._isVisible(el)) {
             this._focusedElement = el;
             return el.focus();
           }
@@ -517,30 +518,33 @@ This program is available under Apache License Version 2.0, available at https:/
         return elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length;
       }
 
-      _getFocusableElements() {
-        // collect all focusable elements
-        const focusableElements = Array.from(this.$.content.querySelectorAll(
-          '[tabindex], button, input, select, textarea, object, iframe, label, a[href], area[href]'
-        )).filter((el) => {
-          return el.getAttribute('tabindex') !== '-1';
-        });
+      _tabindex(e) {
+        // Should use `element.tabIndex` which returns -1 when the element is not focusable, and 0
+        // when the element is natively focusable. Though, IE and Edge returns zero for both, hence
+        // we need to deal with attribute values and tag-names to correctly compute it.
+        let i = parseInt(e.getAttribute('tabindex'));
+        i = !isNaN(i) ? i : /^(button|input|select|textarea|object|iframe|a|area)$/i.test(e.localName) ? 0 : -1;
+        // tabIndex zero has the lowest preference, thus setting it to Infinity allows natural sorting.
+        return i ? i : Infinity;
+      }
 
-        // sort focusable elements according to tabindex
-        return focusableElements.sort((a, b) => {
-          a = parseInt(a.getAttribute('tabindex')) || 0;
-          b = parseInt(b.getAttribute('tabindex')) || 0;
-          if (a === b) {
-            return 0;
-          } else if (a === 0) {
-            return 1;
-          } else if (b === 0) {
-            return -1;
-          } else if (a < b) {
-            return -1;
-          } else if (a > b) {
-            return 1;
-          }
-        });
+      // Recursively collect all focusable elements deeping into shadowRoots
+      _focusableArray(elem) {
+        const arr = elem.shadowRoot && this._tabindex(elem) >= 0 ? [] :
+          Array.from((elem.shadowRoot || elem).querySelectorAll('*'));
+
+        return arr
+          .reduce((prev, e) => prev.concat(this._focusableArray(e)), [elem])
+          .filter(e => this._tabindex(e) >= 0)
+          .sort((a, b) => this._tabindex(a) > this._tabindex(b));
+      }
+
+      _getFocusableElements() {
+        return this._focusableElements || (this._focusableElements = this._focusableArray(this.$.content));
+      }
+
+      _focusTrapChanged() {
+        delete this._focusableElements;
       }
 
       _processPendingMutationObserversFor(node) {

--- a/vaadin-overlay.html
+++ b/vaadin-overlay.html
@@ -347,6 +347,10 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       }
 
+      _isFocused(element) {
+        return element && element.getRootNode().activeElement === element;
+      }
+
       /**
        * @event vaadin-overlay-escape-press
        * fired before the `vaadin-overlay` will be closed on ESC button press. If canceled the closing of the overlay is canceled as well.
@@ -359,19 +363,18 @@ This program is available under Apache License Version 2.0, available at https:/
         // TAB
         if (event.key === 'Tab' && this.focusTrap) {
           const focusableElements = this._getFocusableElements();
-          const focusedElementIndex = focusableElements.indexOf(this._focusedElement);
-
-          // Cycle to the next button
-          if (!event.shiftKey) {
-            this._setFocus(focusedElementIndex, 1);
-
-          // Cycle to the prev button
-          } else {
-            this._setFocus(focusedElementIndex, -1);
+          // _focusedElement might be wrong when the user moves the focus by mouse or programatically
+          if (!this._isFocused(this._focusedElement)) {
+            this._focusedElement = focusableElements.reduce((prev, e) => {
+              return !prev && e.getRootNode().activeElement === e ? e : prev;
+            }, undefined);
           }
 
+          if (this._isFocused(this._focusedElement)) {
+            // Move focus to the next/previous element
+            this._setFocus(focusableElements.indexOf(this._focusedElement), event.shiftKey ? -1 : 1);
+          }
           event.preventDefault();
-
         // ESC
         } else if (event.key === 'Escape' || event.key === 'Esc') {
           const evt = new CustomEvent('vaadin-overlay-escape-press', {bubbles: true, cancelable: true, detail: {sourceEvent: event}});


### PR DESCRIPTION
Connects to #45 
This is an alternative to #46 

Advantages: 
- It does not introduce significant changes to the previous implementation.
- It works in shady and shadow dom.

Issues:
- When having shadow elements adding more focusable elements they are uncovered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/54)
<!-- Reviewable:end -->
