### PR TITLE
Fix focus trap to account for custom web components with focusable children

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "polymer": "^2.0.0",
     "vaadin-themable-mixin": "^1.1.1",
-    "vaadin-valo-styles": "vaadin/vaadin-valo-styles#^2.0.0"
+    "vaadin-valo-styles": "vaadin/vaadin-valo-styles#^2.0.0",
+    "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^2.2.1"
   },
   "devDependencies": {
     "elements-demo-resources": "^2.0.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,6 +9,8 @@
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../vaadin-button/vaadin-button.html">
+  <link rel="import" href="../../vaadin-date-picker/vaadin-date-picker.html">
+  <link rel="import" href="../../vaadin-combo-box/vaadin-combo-box.html">
   <link rel="import" href="common.html">
 </head>
 
@@ -60,6 +62,17 @@
             <button tabindex="1">button with tabindex="1"</button>
             <input type="text">
             <vaadin-button>vaadin-button</vaadin-button>
+
+            <hr size="1" />
+            <h3>Custom components also participate in focus trap</h3>
+
+            <vaadin-date-picker label="Date of Birth"></vaadin-date-picker>
+            <br>
+            <vaadin-combo-box label="Favourite Color" items='[{"label": "Blue"}, {"label": "Pink"}, {"label": "Magenta"}]'>
+              <template>
+                [[index]]: <b> [[item.label]]</b>
+              </template>
+            </vaadin-combo-box>
           </template>
         </vaadin-overlay>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,8 +9,6 @@
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../vaadin-button/vaadin-button.html">
-  <link rel="import" href="../../vaadin-date-picker/vaadin-date-picker.html">
-  <link rel="import" href="../../vaadin-combo-box/vaadin-combo-box.html">
   <link rel="import" href="common.html">
 </head>
 
@@ -62,17 +60,6 @@
             <button tabindex="1">button with tabindex="1"</button>
             <input type="text">
             <vaadin-button>vaadin-button</vaadin-button>
-
-            <hr size="1" />
-            <h3>Custom components also participate in focus trap</h3>
-
-            <vaadin-date-picker label="Date of Birth"></vaadin-date-picker>
-            <br>
-            <vaadin-combo-box label="Favourite Color" items='[{"label": "Blue"}, {"label": "Pink"}, {"label": "Magenta"}]'>
-              <template>
-                [[index]]: <b> [[item.label]]</b>
-              </template>
-            </vaadin-combo-box>
           </template>
         </vaadin-overlay>
 

--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -346,17 +346,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
         // TAB
         if (event.key === 'Tab' && this.focusTrap) {
-          const focusableElements = this._getFocusableElements();
-          const focusedElementIndex = focusableElements.indexOf(this._focusedElement);
-
-          // Cycle to the next button
-          if (!event.shiftKey) {
-            this._setFocus(focusedElementIndex, 1, focusableElements);
-
-          // Cycle to the prev button
-          } else {
-            this._setFocus(focusedElementIndex, -1, focusableElements);
-          }
+          // if only tab key is pressed, cycle forward, else cycle backwards.
+          this._cycleTab(event.shiftKey ? -1 : 1);
 
           event.preventDefault();
 
@@ -386,7 +377,7 @@ This program is available under Apache License Version 2.0, available at https:/
               // Focus
               //  - the overlay content by default
               //  - or the first focusable element if focusTrap is true
-              this._setFocus(-1, 1);
+              this._cycleTab(1, -1);
             }
 
             const evt = new CustomEvent('vaadin-overlay-open', {bubbles: true});
@@ -467,11 +458,12 @@ This program is available under Apache License Version 2.0, available at https:/
         this.$.content.appendChild(content);
       }
 
-      _setFocus(index, increment, focusableElements) {
+      _cycleTab(increment, index) {
         if (!this.focusTrap) {
           return;
         }
-        focusableElements = focusableElements || this._getFocusableElements();
+        const focusableElements = this._getFocusableElements();
+        index = index || focusableElements.indexOf(this._focusedElement);
 
         // search for visible elements and select the next possible match
         for (let i = 0; i < focusableElements.length; i++) {
@@ -488,10 +480,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
           // determine if element is visible
           const el = focusableElements[index];
-          if (this._isVisible(el)) {
-            this._focusedElement = el;
-            return el.focus();
-          }
+          this._focusedElement = el;
+          return el.focus();
         }
 
         // fallback if there are no focusable elements
@@ -499,14 +489,9 @@ This program is available under Apache License Version 2.0, available at https:/
         this.$.overlay.focus();
       }
 
-      // borrowed from jqeury $(elem).is(':visible') implementation
-      _isVisible(elem) {
-        return elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length;
-      }
-
-      _getFocusableElements(container) {
+      _getFocusableElements() {
         // collect all focusable elements
-        return Polymer.IronFocusablesHelper.getTabbableNodes(container || this.$.content).
+        return Polymer.IronFocusablesHelper.getTabbableNodes(this.$.content).
           filter(element => !element.shadowRoot || Polymer.IronFocusablesHelper.getTabbableNodes(element).length === 0);
       }
 

--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -9,6 +9,7 @@ This program is available under Apache License Version 2.0, available at https:/
 <link rel="import" href="../../polymer/lib/utils/render-status.html">
 <link rel="import" href="../../polymer/lib/utils/flattened-nodes-observer.html">
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
+<link rel="import" href="../../iron-overlay-behavior/iron-focusables-helper.html">
 
 <dom-module id="vaadin-overlay">
   <template>
@@ -350,11 +351,11 @@ This program is available under Apache License Version 2.0, available at https:/
 
           // Cycle to the next button
           if (!event.shiftKey) {
-            this._setFocus(focusedElementIndex, 1);
+            this._setFocus(focusedElementIndex, 1, focusableElements);
 
           // Cycle to the prev button
           } else {
-            this._setFocus(focusedElementIndex, -1);
+            this._setFocus(focusedElementIndex, -1, focusableElements);
           }
 
           event.preventDefault();
@@ -466,12 +467,11 @@ This program is available under Apache License Version 2.0, available at https:/
         this.$.content.appendChild(content);
       }
 
-      _setFocus(index, increment) {
+      _setFocus(index, increment, focusableElements) {
         if (!this.focusTrap) {
           return;
         }
-
-        const focusableElements = this._getFocusableElements();
+        focusableElements = focusableElements || this._getFocusableElements();
 
         // search for visible elements and select the next possible match
         for (let i = 0; i < focusableElements.length; i++) {
@@ -504,30 +504,10 @@ This program is available under Apache License Version 2.0, available at https:/
         return elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length;
       }
 
-      _getFocusableElements() {
+      _getFocusableElements(container) {
         // collect all focusable elements
-        const focusableElements = Array.from(this.$.content.querySelectorAll(
-          '[tabindex], button, input, select, textarea, object, iframe, label, a[href], area[href]'
-        )).filter((el) => {
-          return el.getAttribute('tabindex') !== '-1';
-        });
-
-        // sort focusable elements according to tabindex
-        return focusableElements.sort((a, b) => {
-          a = parseInt(a.getAttribute('tabindex')) || 0;
-          b = parseInt(b.getAttribute('tabindex')) || 0;
-          if (a === b) {
-            return 0;
-          } else if (a === 0) {
-            return 1;
-          } else if (b === 0) {
-            return -1;
-          } else if (a < b) {
-            return -1;
-          } else if (a > b) {
-            return 1;
-          }
-        });
+        return Polymer.IronFocusablesHelper.getTabbableNodes(container || this.$.content).
+          filter(element => !element.shadowRoot || Polymer.IronFocusablesHelper.getTabbableNodes(element).length === 0);
       }
 
       _processPendingMutationObserversFor(node) {

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -6,10 +6,28 @@
   <script src="../../web-component-tester/browser.js"></script>
   <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
   <link rel="import" href="../../vaadin-button/vaadin-button.html">
+  <link rel="import" href="../../vaadin-text-field/vaadin-text-field.html">
   <link rel="import" href="../vaadin-overlay.html">
+  <link rel="import" href="../../polymer/polymer-element.html">
 </head>
 
 <body>
+  <dom-module id="container-with-shadow">
+    <template>
+      <input type="text" id="text">
+      <vaadin-text-field></vaadin-text-field>
+    </template>
+    <script>
+      document.addEventListener('WebComponentsReady', () => {
+        window.customElements.define('container-with-shadow', class extends Polymer.Element {
+          static get is() {
+            return 'container-with-shadow';
+          }
+        });
+      });
+    </script>
+  </dom-module>
+
   <test-fixture id="default">
     <template>
       <div>
@@ -40,6 +58,18 @@
           </vaadin-overlay>
         </div>
       </div>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="focus-trap">
+    <template>
+      <vaadin-overlay>
+        <template>
+          <container-with-shadow>
+          </container-with-shadow>
+          <input type="text" id="text">
+        </template>
+      </vaadin-overlay>
     </template>
   </test-fixture>
 
@@ -527,6 +557,17 @@
         expect(focusableElements[2]).to.eql(overlay.$.content.querySelector('button'));
         expect(focusableElements[3]).to.eql(overlay.$.content.querySelector('input'));
         expect(focusableElements[4]).to.eql(overlay.$.content.querySelector('vaadin-button').shadowRoot.querySelector('button'));
+      });
+
+      it('should properly detect multiple focusables in web component shadowRoots', () => {
+        const overlay = fixture('focus-trap');
+        overlay.focusTrap = true;
+
+        const focusableElements = overlay._getFocusableElements();
+
+        expect(focusableElements.length).to.eql(3);
+        expect(focusableElements[0]).to.eql(
+          overlay.$.content.querySelector('container-with-shadow').$.text);
       });
 
       it('should focus focusable elements inside the content when focusTrap = true', (done) => {

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -526,7 +526,7 @@
         expect(focusableElements[1]).to.eql(overlay.$.content.querySelector('select'));
         expect(focusableElements[2]).to.eql(overlay.$.content.querySelector('button'));
         expect(focusableElements[3]).to.eql(overlay.$.content.querySelector('input'));
-        expect(focusableElements[4]).to.eql(overlay.$.content.querySelector('vaadin-button'));
+        expect(focusableElements[4]).to.eql(overlay.$.content.querySelector('vaadin-button').shadowRoot.querySelector('button'));
       });
 
       it('should focus focusable elements inside the content when focusTrap = true', (done) => {


### PR DESCRIPTION
Fixes #45
Closes #46
Closes #54

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/58)
<!-- Reviewable:end -->