### PR TITLE
Add `--vaadin-overlay-context-width` CSS property

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -232,6 +232,48 @@
         </style>
       </template>
     </dom-module>
+
+    <h3>Using the parent/context width to control the width of the overlay</h3>
+    <demo-snippet>
+      <template>
+        <dom-module id="overlay-width" theme-for="vaadin-overlay">
+          <template>
+            <style>
+              :host(.context-width) [part="overlay"] {
+                min-width: var(--vaadin-overlay-context-width);
+                background-color: #fff;
+                border: 1px solid;
+              }
+            </style>
+          </template>
+        </dom-module>
+        <p>Makes the overlay adapts it’s width to its context (the <code>&lt;demo-snippet&gt;</code> element in this case). The width is updated when the overlay is opened, not continously (e.g. when browser window resize cause the parent/context width to change).</p>
+        <vaadin-overlay class="context-width">
+          <template>The overlay width is always at least as wide as the context it is placed in. The overlay still grows with its content.</template>
+        </vaadin-overlay>
+        <vaadin-button id="button-overlay-context-width">Show the overlay</vaadin-button>
+        <script>
+          document.getElementById('button-overlay-context-width').addEventListener('click', event => {
+            const overlay = event.target.previousElementSibling;
+            overlay.opened = true;
+          });
+        </script>
+      </template>
+    </demo-snippet>
+
+    <!-- Needs to be duplicated for polyfilled browsers, doesn’t work from inside demo-snippet -->
+    <dom-module id="overlay-width" theme-for="vaadin-overlay">
+      <template>
+        <style>
+          :host(.context-width) [part="overlay"] {
+            min-width: var(--vaadin-overlay-context-width);
+            background-color: #fff;
+            border: 1px solid;
+          }
+        </style>
+      </template>
+    </dom-module>
+
   </div>
 </body>
 </html>

--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -116,6 +116,7 @@ This program is available under Apache License Version 2.0, available at https:/
      * Custom CSS property | Description | Default value
      * ---|---|---
      * `--vaadin-overlay-viewport-bottom` | Bottom offset of the visible viewport area | `0` or detected offset
+     * `--vaadin-overlay-context-width` | The `offsetWidth` of the parent/host element of the overlay (e.g. vaadin-dropdown-menu host) |
      *
      * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
      *
@@ -406,6 +407,8 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _attachOverlay() {
+        const parent = this.parentNode.host || this.parentNode;
+        this.updateStyles({'--vaadin-overlay-context-width': parent.offsetWidth + 'px'});
         this._placeholder = document.createComment('vaadin-overlay-placeholder');
         this.parentNode.insertBefore(this._placeholder, this);
         document.body.appendChild(this);


### PR DESCRIPTION
Allow the theme to use the context width to size the overlay.

One use case for this is to set a `min-width` for `vaadin-dropdown-menu-overlay` so that it matches the width of `vaadin-dropdown-menu-text-field`.

This implementation is debatable if it is the best way to support the above use case. We could also choose to implement this in those elements specifically which benefit from this (dropdown-menu, combo-box, and date-picker).

Also, it can be argued that we should also then expose `--vaadin-overlay-context-height`. IMO we can postpone that for later if we come up with a use case for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/63)
<!-- Reviewable:end -->
