### PR TITLE
Fix opening animations for Safari

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -393,16 +393,18 @@ This program is available under Apache License Version 2.0, available at https:/
       _animatedOpening() {
         this._attachOverlay();
         this.setAttribute('opening', '');
-        const name = getComputedStyle(this).getPropertyValue('animation-name');
-        if (name && name != 'none') {
-          const listener = () => {
-            this.removeEventListener('animationend', listener);
+        setTimeout(() => {
+          const name = getComputedStyle(this).getPropertyValue('animation-name');
+          if (name && name != 'none') {
+            const listener = () => {
+              this.removeEventListener('animationend', listener);
+              this.removeAttribute('opening');
+            };
+            this.addEventListener('animationend', listener);
+          } else {
             this.removeAttribute('opening');
-          };
-          this.addEventListener('animationend', listener);
-        } else {
-          this.removeAttribute('opening');
-        }
+          }
+        }, 1);
       }
 
       _attachOverlay() {
@@ -560,4 +562,3 @@ This program is available under Apache License Version 2.0, available at https:/
     Vaadin.OverlayElement = OverlayElement;
   })();
 </script>
-

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -9,6 +9,7 @@
     "expect": false,
     "gemini": false,
     "sinon": false,
+    "listenOnce": false,
     "MockInteractions": false
   }
 }

--- a/test/animate-overlay.html
+++ b/test/animate-overlay.html
@@ -1,0 +1,96 @@
+<!doctype html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>vaadin-overlay tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+  <link rel="import" href="../vaadin-overlay.html">
+  <script src="common.js"></script>
+</head>
+
+<body>
+  <dom-module id="overlay-animations" theme-for="vaadin-overlay">
+    <template>
+      <style>
+        :host([opening]) {
+          animation: vaadin-overlay-enter 50ms;
+        }
+
+        @keyframes vaadin-overlay-enter {
+          0% {
+            opacity: 0;
+            transform: rotate(180deg);
+          }
+        }
+
+        :host([closing]) {
+          animation: vaadin-overlay-exit 50ms;
+        }
+
+        @keyframes vaadin-overlay-exit {
+          100% {
+            opacity: 0;
+            transform: rotate(180deg);
+          }
+        }
+      </style>
+    </template>
+  </dom-module>
+
+  <test-fixture id="default">
+    <template>
+      <div>
+        <div id="parent">
+          <vaadin-overlay>
+            <template>
+              Content
+            </template>
+          </vaadin-overlay>
+        </div>
+      </div>
+    </template>
+  </test-fixture>
+
+  <script>
+    describe('overlay', function() {
+      var overlay, parent;
+
+      beforeEach(() => {
+        parent = fixture('default').children[0];
+        overlay = parent.children[0];
+        overlay._observer.flush();
+        overlay.opened = true;
+      });
+
+      afterEach(done => {
+        // Avoid stacking up <vaadin-overlay> elements in the body.
+        overlay.opened = false;
+        setTimeout(done, 100);
+      });
+
+      it('should set `opening` attribute and remove later', done => {
+        expect(overlay.hasAttribute('opening')).to.be.true;
+
+        listenOnce(overlay, 'animationend', () => {
+          setTimeout(() => {
+            expect(overlay.hasAttribute('opening')).to.be.false;
+            done();
+          });
+        });
+      });
+
+      it('should set `closing` attribute and remove later', done => {
+        overlay.opened = false;
+        expect(overlay.hasAttribute('closing')).to.be.true;
+
+        listenOnce(overlay, 'animationend', () => {
+          setTimeout(() => {
+            expect(overlay.hasAttribute('closing')).to.be.false;
+            done();
+          });
+        });
+      });
+    });
+  </script>
+</body>

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,7 @@
+window.listenOnce = (elem, type, callback) => {
+  const listener = () => {
+    elem.removeEventListener(type, listener);
+    callback();
+  };
+  elem.addEventListener(type, listener);
+};

--- a/test/test-suites.js
+++ b/test/test-suites.js
@@ -1,4 +1,6 @@
 window.VaadinOverlaySuites = [
   'vaadin-overlay.html',
-  'vaadin-overlay.html?wc-shadydom=true'
+  'vaadin-overlay.html?wc-shadydom=true',
+  'animate-overlay.html',
+  'animate-overlay.html?wc-shadydom=true'
 ];


### PR DESCRIPTION
Without the timeout, Safari doesn’t render the opening animation for vaadin-dropdown-menu on small viewport sizes.

I’m not entirely sure why this fixes the animation on Safari. It might be that this is not the correct fix. But it seems like the style modules (or the media queries) are processed after vaadin-overlay looks for the `animation` property from computed style.

Should be reproducible with https://github.com/vaadin/vaadin-lumo-styles/pull/9 and vaadin-dropdown-menu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/64)
<!-- Reviewable:end -->
