### PR TITLE
Fix shift-tab escaping from overlay

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -506,13 +506,15 @@ This program is available under Apache License Version 2.0, available at https:/
         }
         const focusableElements = this._getFocusableElements();
 
-        if (!this._isFocused(this._focusedElement)) {
-          this._focusedElement = focusableElements.reduce((prev, e) => {
-            return !prev && e.getRootNode().activeElement === e ? e : prev;
-          }, undefined);
+        if (index === undefined) {
+          index = focusableElements.indexOf(this._focusedElement);
+          if (!this._isFocused(this._focusedElement)) {
+            this._focusedElement = focusableElements.reduce((prev, e) => {
+              return !prev && e.getRootNode().activeElement === e ? e : prev;
+            }, undefined);
+          }
+          index = this._focusedElement ? focusableElements.indexOf(this._focusedElement) : index;
         }
-
-        index = index || focusableElements.indexOf(this._focusedElement);
 
         // search for visible elements and select the next possible match
         for (let i = 0; i < focusableElements.length; i++) {
@@ -528,9 +530,10 @@ This program is available under Apache License Version 2.0, available at https:/
           }
 
           // determine if element is visible
-          const el = focusableElements[index];
-          this._focusedElement = el;
-          return el.focus();
+          this._focusedElement = focusableElements[index];
+          if (this._focusedElement) {
+            return this._focusedElement.focus();
+          }
         }
 
         // fallback if there are no focusable elements

--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -510,7 +510,7 @@ This program is available under Apache License Version 2.0, available at https:/
           index = focusableElements.indexOf(this._focusedElement);
           if (!this._isFocused(this._focusedElement)) {
             this._focusedElement = focusableElements.reduce((prev, e) => {
-              return !prev && e.getRootNode().activeElement === e ? e : prev;
+              return !prev && this._isFocused(e) ? e : prev;
             }, undefined);
           }
           index = this._focusedElement ? focusableElements.indexOf(this._focusedElement) : index;

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -609,6 +609,21 @@
         overlay.opened = true;
       });
 
+      it('should not throw using Shift Tab on elements with shadow root', (done) => {
+        overlay.focusTrap = true;
+        overlay.addEventListener('vaadin-overlay-open', () => {
+          const button = overlay.$.content.querySelector('vaadin-button');
+
+          button.focus();
+          button.blur();
+
+          MockInteractions.pressAndReleaseKeyOn(document.body, 9, 'shift', 'Tab');
+
+          done();
+        });
+        overlay.opened = true;
+      });
+
       describe('empty content', function() {
         beforeEach(function() {
           parent = fixture('empty').children[0];


### PR DESCRIPTION
Fixes #66 

Thanks to @manolo for implementation, I have just slightly simplified the code and added the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/67)
<!-- Reviewable:end -->
