### PR TITLE
Disable closing of the overlay by clicking on notification content

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,6 +33,7 @@
     "iron-component-page": "^3.0.0",
     "iron-demo-helpers": "^2.0.0",
     "iron-test-helpers": "^2.0.0",
+    "vaadin-notification": "^1.0.0",
     "vaadin-button": "^2.0.0",
     "iron-form": "^2.0.0",
     "iron-input": "^2.0.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,6 +9,7 @@
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../vaadin-button/vaadin-button.html">
+  <link rel="import" href="../../vaadin-notification/vaadin-notification.html">
   <link rel="import" href="common.html">
 </head>
 
@@ -201,6 +202,41 @@
             overlay.opened = true;
           });
         </script>
+      </template>
+    </demo-snippet>
+
+
+    <h3>Overlay opened along with notification</h3>
+    <demo-snippet>
+      <template preserve-content>
+        <dom-bind id="bind-elm">
+          <template>
+            <vaadin-overlay id="overlay">
+              <template>I will not be closed by clicking on notification</template>
+            </vaadin-overlay>
+            <vaadin-notification id="notification" duration="0" position="bottom-end">
+              <template>
+                This notification remains opened until the button inside is clicked.
+                <vaadin-button on-click="_close">Close</vaadin-button>
+              </template>
+            </vaadin-notification>
+            <vaadin-button on-click="_open" id="button-overlay-notification">Show the overlay with notification</vaadin-button>
+            <script>
+              window.addEventListener('WebComponentsReady', function() {
+                const domBind = document.querySelector('#bind-elm');
+                const overlay = document.querySelector('#overlay');
+                const notification = document.querySelector('#notification');
+                domBind._open = function() {
+                  overlay.opened = true;
+                  notification.open();
+                };
+                domBind._close = function() {
+                  notification.close();
+                };
+              });
+            </script>
+          </template>
+        </dom-bind>
       </template>
     </demo-snippet>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -206,7 +206,7 @@
     </demo-snippet>
 
 
-    <h3>Overlay opened along with notification</h3>
+    <h3>Overlay Opened Along With Notification</h3>
     <demo-snippet>
       <template preserve-content>
         <dom-bind id="bind-elm">

--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -322,7 +322,8 @@ This program is available under Apache License Version 2.0, available at https:/
           this._mouseUpInside = false;
           return;
         }
-        if (!this._last) {
+
+        if (!this._last || event.composedPath().filter(el => el.localName === 'vaadin-notification-card')[0]) {
           return;
         }
 

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -6,6 +6,7 @@
   <script src="../../web-component-tester/browser.js"></script>
   <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
   <link rel="import" href="../../vaadin-button/vaadin-button.html">
+  <link rel="import" href="../../vaadin-notification/vaadin-notification.html">
   <link rel="import" href="../../vaadin-text-field/vaadin-text-field.html">
   <link rel="import" href="../vaadin-overlay.html">
   <link rel="import" href="../../polymer/polymer-element.html">
@@ -56,6 +57,23 @@
             <template>
             </template>
           </vaadin-overlay>
+        </div>
+      </div>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="overlay-with-notification">
+    <template>
+      <div>
+        <div id="parent">
+          <vaadin-overlay focus-trap>
+            <template>
+            </template>
+          </vaadin-overlay>
+          <vaadin-notification duration="0">
+            <template>
+            </template>
+          </vaadin-notification>
         </div>
       </div>
     </template>
@@ -641,6 +659,23 @@
         });
       });
 
+    });
+
+    describe('overlay with notification', function() {
+      var overlay, parent, notification;
+
+      beforeEach(function() {
+        parent = fixture('overlay-with-notification').children[0];
+        overlay = parent.children[0];
+        notification = parent.children[1];
+      });
+
+      it('should not close the overlay by clicking on notification', () => {
+        overlay.opened = true;
+        notification.open();
+        click(document.querySelector('vaadin-notification-card'));
+        expect(overlay.opened).to.be.true;
+      });
     });
   </script>
 </body>

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -64,16 +64,14 @@
 
   <test-fixture id="overlay-with-notification">
     <template>
-      <div id="parent">
-        <vaadin-overlay focus-trap>
-          <template>
-          </template>
-        </vaadin-overlay>
-        <vaadin-notification duration="0">
-          <template>
-          </template>
-        </vaadin-notification>
-      </div>
+      <vaadin-overlay focus-trap>
+        <template>
+        </template>
+      </vaadin-overlay>
+      <vaadin-notification duration="0">
+        <template>
+        </template>
+      </vaadin-notification>
     </template>
   </test-fixture>
 
@@ -660,12 +658,10 @@
     });
 
     describe('overlay with notification', function() {
-      var overlay, parent, notification;
+      let overlay, notification;
 
       beforeEach(function() {
-        parent = fixture('overlay-with-notification');
-        overlay = parent.children[0];
-        notification = parent.children[1];
+        [overlay, notification] = fixture('overlay-with-notification');
       });
 
       it('should not close the overlay by clicking on notification', () => {

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -64,17 +64,15 @@
 
   <test-fixture id="overlay-with-notification">
     <template>
-      <div>
-        <div id="parent">
-          <vaadin-overlay focus-trap>
-            <template>
-            </template>
-          </vaadin-overlay>
-          <vaadin-notification duration="0">
-            <template>
-            </template>
-          </vaadin-notification>
-        </div>
+      <div id="parent">
+        <vaadin-overlay focus-trap>
+          <template>
+          </template>
+        </vaadin-overlay>
+        <vaadin-notification duration="0">
+          <template>
+          </template>
+        </vaadin-notification>
       </div>
     </template>
   </test-fixture>
@@ -665,7 +663,7 @@
       var overlay, parent, notification;
 
       beforeEach(function() {
-        parent = fixture('overlay-with-notification').children[0];
+        parent = fixture('overlay-with-notification');
         overlay = parent.children[0];
         notification = parent.children[1];
       });


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-notification/issues/56

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/70)
<!-- Reviewable:end -->
