### PR TITLE
Support `is` only for non-custom elements

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -583,8 +583,10 @@ This program is available under Apache License Version 2.0, available at https:/
 
           if (window.ShadyCSS && !window.ShadyCSS.nativeShadow) {
             // Shady DOM
-            this._shadyStyleScope = templateRoot.host
-              && (templateRoot.host.getAttribute('is') || templateRoot.host.localName);
+            this._shadyStyleScope = templateRoot.host && templateRoot.host.localName;
+            if (this._shadyStyleScope && this._shadyStyleScope.indexOf('-') === -1) {
+              this._shadyStyleScope = templateRoot.host.getAttribute('is');
+            }
             if (this._shadyStyleScope) {
               // NOTE(platosha): here we trick ShadyCSS to think that the scope is
               // what `this._shadyStyleScope` says. What we actually need is to add

--- a/test/styling.html
+++ b/test/styling.html
@@ -75,6 +75,28 @@
     </template>
   </test-fixture>
 
+  <dom-module id="is-custom-element">
+    <template>
+      <vaadin-overlay>
+        <template>is-custom-element</template>
+      </vaadin-overlay>
+    </template>
+  </dom-module>
+  <script>
+    addEventListener('WebComponentsReady', () => {
+      customElements.define('is-custom-element', class extends Polymer.Element {
+        static get is() {
+          return 'is-custom-element';
+        }
+      });
+    });
+  </script>
+  <test-fixture id="isCustomElement">
+    <template>
+      <is-custom-element is="is-value"></is-custom-element>
+    </template>
+  </test-fixture>
+
   <script>
     function getComputedStyleSource(element) {
       return window.getComputedStyle(element).getPropertyValue('font-family')
@@ -162,6 +184,34 @@
           )).to.not.equal('.local-styles-content');
         });
       });
+
+      if (window.ShadyCSS && !window.ShadyCSS.nativeShadow) {
+        describe('ShadyCSS scoping with is attribute', () => {
+          function getStyleScope(overlay) {
+            return overlay.$.content.getAttribute('is');
+          }
+
+          it('should use is value for builtin elements', () => {
+            const template = document.createElement('template');
+            template.innerHTML = 'is-builtin-element';
+            const overlay = document.createElement('vaadin-overlay');
+            overlay.appendChild(template);
+            const owner = document.createElement('div');
+            owner.setAttribute('is', 'is-builtin-element');
+            owner.attachShadow({mode: 'open'});
+            owner.shadowRoot.appendChild(overlay);
+            document.body.appendChild(owner);
+            expect(getStyleScope(overlay)).to.equal('is-builtin-element');
+            document.body.removeChild(owner);
+          });
+
+          it('should not use is value for custom elements', () => {
+            const owner = fixture('isCustomElement');
+            const overlay = owner.shadowRoot.querySelector('vaadin-overlay');
+            expect(getStyleScope(overlay)).to.equal('is-custom-element');
+          });
+        });
+      }
     });
   </script>
 </body>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/83)
<!-- Reviewable:end -->
