### PR TITLE
Prevent late detaching when `opened` is true

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -477,6 +477,13 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _detachOverlay() {
+        // The detaching overlay is happening after closing animation is finished.
+        // If in the meantime of closing animation user quickly clicked
+        // the element to show the same ovelay, `opened` will be true
+        // and no need to detach the overlay
+        if (this.opened || !this._placeholder.parentNode) {
+          return;
+        }
         this._placeholder.parentNode.insertBefore(this, this._placeholder);
         this._processPendingMutationObserversFor(document.body);
         this._placeholder.parentNode.removeChild(this._placeholder);


### PR DESCRIPTION
Fixes #80 

The test suite is in https://github.com/vaadin/vaadin-dropdown-menu/pull/116

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/84)
<!-- Reviewable:end -->
