### PR TITLE
Remove this._placeholder usage

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -453,33 +453,37 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _attachOverlay() {
-        this._placeholder = document.createComment('vaadin-overlay-placeholder');
-        this.parentNode.insertBefore(this._placeholder, this);
         document.body.appendChild(this);
       }
 
       _animatedClosing() {
-        if (this._placeholder) {
-          this.setAttribute('closing', '');
-          const name = getComputedStyle(this).getPropertyValue('animation-name');
-          if (name && name != 'none') {
-            const listener = () => {
-              this._detachOverlay();
-              this.removeAttribute('closing');
-              this.removeEventListener('animationend', listener);
-            };
-            this.addEventListener('animationend', listener);
-          } else {
+        this.setAttribute('closing', '');
+        const name = getComputedStyle(this).getPropertyValue('animation-name');
+        if (name && name != 'none') {
+          const listener = () => {
             this._detachOverlay();
             this.removeAttribute('closing');
-          }
+            this.removeEventListener('animationend', listener);
+          };
+          this.addEventListener('animationend', listener);
+        } else {
+          this._detachOverlay();
+          this.removeAttribute('closing');
         }
       }
 
       _detachOverlay() {
-        this._placeholder.parentNode.insertBefore(this, this._placeholder);
-        this._processPendingMutationObserversFor(document.body);
-        this._placeholder.parentNode.removeChild(this._placeholder);
+        // The detaching overlay is happening after closing animation is finished.
+        // If in the meantime of closing animation user quickly clicked
+        // the element to show the same ovelay, `opened` will be true
+        // and no need to detach the overlay
+        if (this.opened) {
+          return;
+        }
+
+        if (this.parentNode === document.body) {
+          document.body.removeChild(this);
+        }
       }
 
       /**

--- a/test/templating.html
+++ b/test/templating.html
@@ -148,7 +148,6 @@
 
           afterEach(() => {
             overlay.opened = false;
-            overlay.getRootNode().removeChild(externalTemplate);
             Polymer.Templatize.templatize.restore();
           });
 

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -81,12 +81,6 @@
         expect(document.body.style.pointerEvents).to.eql('');
       });
 
-      it('should move back to original place after closing', () => {
-        overlay.opened = false;
-
-        expect(overlay.parentElement).to.eql(parent);
-      });
-
       describe('multiple overlays', function() {
         let overlay1, overlay2;
 


### PR DESCRIPTION
Fixes #80

The test suites are in vaadin/vaadin-dropdown-menu#116

For better CR experience, please use `?w=1`: https://github.com/vaadin/vaadin-overlay/pull/85/files?w=1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/85)
<!-- Reviewable:end -->
