### PR TITLE
Fix template stamping when initially opened

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -454,11 +454,19 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       }
 
+      _ensureTemplatized() {
+        this._setTemplateFromNodes(Array.from(this.children));
+      }
+
       /**
        * @event vaadin-overlay-open
        * fired after the `vaadin-overlay` is opened.
        */
       _openedChanged(opened) {
+        if (!this._instance) {
+          this._ensureTemplatized();
+        }
+
         if (opened) {
           this._animatedOpening();
 

--- a/test/templating.html
+++ b/test/templating.html
@@ -102,7 +102,7 @@
       describe('template with initially opened overlay', () => {
         let openedOverlayView, overlay;
 
-        beforeEach(() => { 
+        beforeEach(() => {
           openedOverlayView = fixture('openedOverlayView');
           overlay = openedOverlayView.$.overlay;
         });

--- a/test/templating.html
+++ b/test/templating.html
@@ -49,6 +49,31 @@
     });
   </script>
 
+  <dom-module id="opened-overlay-view">
+    <template>
+      <vaadin-overlay id="overlay" opened>
+        <template>
+          overlay content
+        </template>
+      </vaadin-overlay>
+    </template>
+  </dom-module>
+  <script>
+    addEventListener('WebComponentsReady', () => {
+      customElements.define('opened-overlay-view', class extends Polymer.Element {
+        static get is() {
+          return 'opened-overlay-view';
+        }
+      });
+    });
+  </script>
+
+  <test-fixture id="openedOverlayView">
+    <template>
+      <opened-overlay-view></opened-overlay-view>
+    </template>
+  </test-fixture>
+
   <test-fixture id="myOverlayView">
     <template>
       <my-overlay-view></my-overlay-view>
@@ -73,6 +98,19 @@
     describe('overlay templating', () => {
       let overlay;
       let externalTemplate;
+
+      describe('template with initially opened overlay', () => {
+        let openedOverlayView, overlay;
+
+        beforeEach(() => { 
+          openedOverlayView = fixture('openedOverlayView');
+          overlay = openedOverlayView.$.overlay;
+        });
+
+        it('should use content part shadowRoot for contents when initially opened in component scope', () => {
+          expect(overlay.content).to.be.instanceOf(ShadowRoot);
+        });
+      });
 
       describe('in component scope', () => {
         let myOverlayView;


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-date-picker/issues/353
Fix: stylescope was applied incorrectly when `opened` property was set initially/declaratively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/102)
<!-- Reviewable:end -->
