### PR TITLE
Add vaadin-radio-group to the focus-trap tests

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,6 +40,7 @@
     "iron-test-helpers": "^2.0.0",
     "vaadin-button": "vaadin/vaadin-button#^2.1.0",
     "vaadin-text-field": "vaadin/vaadin-text-field#^2.1.1",
+    "vaadin-radio-button": "vaadin/vaadin-radio-button#^1.1.0",
     "iron-form": "^2.0.0",
     "iron-input": "^2.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#1.2.0",

--- a/magi-p3-post.json
+++ b/magi-p3-post.json
@@ -1,0 +1,11 @@
+{
+  "files": [
+    "package.json"
+  ],
+  "from": [
+    "\"resolutions\": {"
+  ],
+  "to": [
+    "\"resolutions\": {\n\"@webcomponents/webcomponentsjs\": \"2.0.0\","
+  ]
+}

--- a/test/focus-trap.html
+++ b/test/focus-trap.html
@@ -11,6 +11,8 @@
   <link rel="import" href="../../polymer/polymer-element.html">
   <link rel="import" href="../../vaadin-button/vaadin-button.html">
   <link rel="import" href="../../vaadin-text-field/vaadin-text-field.html">
+  <link rel="import" href="../../vaadin-radio-button/vaadin-radio-button.html">
+  <link rel="import" href="../../vaadin-radio-button/vaadin-radio-group.html">
 </head>
 
 <body>
@@ -26,6 +28,11 @@
           <vaadin-text-field tabindex="3"></vaadin-text-field>
           <textarea tabindex="1">tabindex 1</textarea>
           <input type="text" value="tabindex 0">
+          <vaadin-radio-group>
+            <vaadin-radio-button>Button 1</vaadin-radio-button>
+            <vaadin-radio-button>Button 2</vaadin-radio-button>
+            <vaadin-radio-button>Button 3</vaadin-radio-button>
+          </vaadin-radio-group>
           <vaadin-button>tabindex 0</vaadin-button>
         </template>
       </vaadin-overlay>
@@ -68,6 +75,11 @@
             <vaadin-text-field tabindex="3"></vaadin-text-field>
             <textarea tabindex="1">tabindex 1</textarea>
             <input type="text" value="tabindex 0">
+            <vaadin-radio-group>
+              <vaadin-radio-button>Button 1</vaadin-radio-button>
+              <vaadin-radio-button>Button 2</vaadin-radio-button>
+              <vaadin-radio-button>Button 3</vaadin-radio-button>
+            </vaadin-radio-group>
             <vaadin-button>tabindex 0</vaadin-button>
           </template>
         </vaadin-overlay>
@@ -146,7 +158,7 @@
         });
 
         it('should properly detect focusable elements inside the content', () => {
-          expect(focusableElements.length).to.eql(9);
+          expect(focusableElements.length).to.eql(11);
           expect(focusableElements[0]).to.eql(overlay.content.querySelector('textarea'));
           expect(focusableElements[1]).to.eql(overlay.content.querySelector('select'));
           expect(focusableElements[2]).to.eql(overlay.content.querySelector('vaadin-text-field'));
@@ -154,8 +166,10 @@
           expect(focusableElements[4]).to.eql(overlay.$.overlay);
           expect(focusableElements[5]).to.eql(overlay.content.querySelector('button'));
           expect(focusableElements[6]).to.eql(overlay.content.querySelector('input'));
-          expect(focusableElements[7]).to.eql(overlay.content.querySelector('vaadin-button'));
-          expect(focusableElements[8]).to.eql(overlay.content.querySelector('vaadin-button').focusElement);
+          expect(focusableElements[7]).to.eql(overlay.content.querySelector('vaadin-radio-button'));
+          expect(focusableElements[8]).to.eql(overlay.content.querySelector('vaadin-radio-button').focusElement);
+          expect(focusableElements[9]).to.eql(overlay.content.querySelector('vaadin-button'));
+          expect(focusableElements[10]).to.eql(overlay.content.querySelector('vaadin-button').focusElement);
         });
 
         it('should focus focusable elements inside the content when focusTrap = true', (done) => {
@@ -341,7 +355,7 @@
         });
 
         it('should properly detect focusable elements inside the content', () => {
-          expect(focusableElements.length).to.eql(9);
+          expect(focusableElements.length).to.eql(11);
           expect(focusableElements[0]).to.eql(overlay.content.querySelector('textarea'));
           expect(focusableElements[1]).to.eql(overlay.content.querySelector('select'));
           expect(focusableElements[2]).to.eql(overlay.content.querySelector('vaadin-text-field'));
@@ -349,8 +363,10 @@
           expect(focusableElements[4]).to.eql(overlay.$.overlay);
           expect(focusableElements[5]).to.eql(overlay.content.querySelector('button'));
           expect(focusableElements[6]).to.eql(overlay.content.querySelector('input'));
-          expect(focusableElements[7]).to.eql(overlay.content.querySelector('vaadin-button'));
-          expect(focusableElements[8]).to.eql(overlay.content.querySelector('vaadin-button').focusElement);
+          expect(focusableElements[7]).to.eql(overlay.content.querySelector('vaadin-radio-button'));
+          expect(focusableElements[8]).to.eql(overlay.content.querySelector('vaadin-radio-button').focusElement);
+          expect(focusableElements[9]).to.eql(overlay.content.querySelector('vaadin-button'));
+          expect(focusableElements[10]).to.eql(overlay.content.querySelector('vaadin-button').focusElement);
         });
 
         if (


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-radio-button/issues/77

(Tests without `radio-button` fix should fail on FF only)

Requires https://github.com/vaadin/vaadin-radio-button/pull/79

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/114)
<!-- Reviewable:end -->
