### PR TITLE
Detach the overlay even if it is scheduled for reopening

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -598,13 +598,6 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _detachOverlay() {
-        // The detaching overlay is happening after closing animation is finished.
-        // If in the meantime of closing animation user quickly clicked
-        // the element to show the same ovelay, `opened` will be true
-        // and no need to detach the overlay
-        if (this.opened || !this._placeholder.parentNode) {
-          return;
-        }
         this._placeholder.parentNode.insertBefore(this, this._placeholder);
         this._placeholder.parentNode.removeChild(this._placeholder);
       }

--- a/test/animations.html
+++ b/test/animations.html
@@ -32,10 +32,10 @@
 
         sinon.stub(overlay, '_shouldAnimate', () => true);
 
-        sinon.stub(overlay, '_enqueueAnimation', type => {
+        sinon.stub(overlay, '_enqueueAnimation', (type, callback) => {
           const handler = `__${type}Handler`;
           overlay[handler] = Polymer.Debouncer.debounce(overlay[handler], Polymer.Async.timeOut, () => {
-            overlay.removeAttribute(type);
+            callback();
           });
         });
 
@@ -43,6 +43,10 @@
           const handler = `__${type}Handler`;
           overlay[handler].flush();
         });
+      });
+
+      afterEach(() => {
+        overlay.opened = false;
       });
 
       it('should flush closing overlay when re-opened while closing animation is in progress', () => {
@@ -60,6 +64,16 @@
         overlay.opened = false;
 
         expect(overlay.hasAttribute('opening')).to.be.false;
+      });
+
+      it('should detach the overlay even if it is scheduled for reopening', () => {
+        overlay.opened = true;
+        overlay.opened = false;
+        overlay.opened = true;
+        overlay.opened = false;
+        overlay._flushAnimation('closing');
+
+        expect(overlay.parentNode).not.to.equal(document.body);
       });
     });
   </script>


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-dialog/issues/123

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/135)
<!-- Reviewable:end -->
