### PR TITLE
Don't animate closing if the overlay is explicilty hidden

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -540,7 +540,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
       _shouldAnimate() {
         const name = getComputedStyle(this).getPropertyValue('animation-name');
-        return name && name != 'none';
+        const hidden = getComputedStyle(this).getPropertyValue('display') === 'none';
+        return !hidden && name && name != 'none';
       }
 
       _enqueueAnimation(type, callback) {

--- a/test/animations.html
+++ b/test/animations.html
@@ -29,8 +29,7 @@
 
       beforeEach(() => {
         overlay = fixture('default');
-
-        sinon.stub(overlay, '_shouldAnimate', () => true);
+        overlay.style.setProperty('animation-name', 'close-anim');
 
         sinon.stub(overlay, '_enqueueAnimation', (type, callback) => {
           const handler = `__${type}Handler`;
@@ -75,6 +74,14 @@
 
         expect(overlay.parentNode).not.to.equal(document.body);
       });
+
+      it('should not animate closing if the overlay is explicilty hidden', () => {
+        overlay.opened = true;
+        overlay.hidden = true;
+        overlay.opened = false;
+        expect(overlay.parentNode).not.to.equal(document.body);
+      });
+
     });
   </script>
 </body>


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-combo-box/issues/751
Closes https://github.com/vaadin/vaadin-dialog/issues/123

`_shouldAnimate` currently determines if the closing sequence is animated or not based on the `animation-name` style property of the overlay. This is enough in most cases, but at least `<vaadin-combo-box>` explicitly [uses the overlay's `hidden` attribute](https://github.com/vaadin/vaadin-combo-box/blob/master/src/vaadin-combo-box-dropdown.html#L24) to temporarily hide the overlay, causing the expected animation not to occur. Because of this, the proper closing sequence for the overlay is never executed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/137)
<!-- Reviewable:end -->
