### PR TITLE
Force close overlay if hidden is set during closing

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -302,6 +302,16 @@ This program is available under Apache License Version 2.0, available at https:/
           },
 
           /**
+           * When set to true, the overlay is hidden. This also closes the overlay
+           * immediately in case there is a closing animation in progress.
+           */
+          hidden: {
+            type: Boolean,
+            reflectToAttribute: true,
+            observer: '_hiddenChanged'
+          },
+
+          /**
            * When true move focus to the first focusable element in the overlay,
            * or to the overlay if there are no focusable elements.
            */
@@ -535,6 +545,12 @@ This program is available under Apache License Version 2.0, available at https:/
         } else if (wasOpened) {
           this._animatedClosing();
           this._exitModalState();
+        }
+      }
+
+      _hiddenChanged(hidden) {
+        if (hidden && this.hasAttribute('closing')) {
+          this._flushAnimation('closing');
         }
       }
 

--- a/test/animations.html
+++ b/test/animations.html
@@ -82,6 +82,12 @@
         expect(overlay.parentNode).not.to.equal(document.body);
       });
 
+      it('should close the overlay if hidden is set while closing', () => {
+        overlay.opened = true;
+        overlay.opened = false;
+        overlay.hidden = true;
+        expect(overlay.parentNode).not.to.equal(document.body);
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
In addition to #137, now the case when `hidden` attribute is set when there is already `closing` is covered as well. Seems that this is what actually happens in combo-box.

Closes vaadin/vaadin-dialog#123

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-overlay/138)
<!-- Reviewable:end -->
