### PR TITLE
Clear an overlay's pointer-event overrides whenever it's closed

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -618,6 +618,8 @@ This program is available under Apache License Version 2.0, available at https:/
           this.setAttribute('closing', '');
 
           const finishClosing = () => {
+            this.shadowRoot.querySelector('[part="overlay"]').style.removeProperty('pointer-events');
+
             this._exitModalState();
 
             document.removeEventListener('iron-overlay-canceled', this._boundIronOverlayCanceledListener);

--- a/test/vaadin-overlay.html
+++ b/test/vaadin-overlay.html
@@ -276,6 +276,22 @@
           expect(getComputedStyle(overlay2Part).pointerEvents).to.equal('auto');
           expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('none');
         });
+
+        it('should clear pointer events', () => {
+          const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
+          // Step 1: Opening overlay 1 so it's physically moved under the body
+          overlay1.opened = true;
+          // Step 2: As overlay2 is modal, it will set overlay 1's pointer events to none
+          overlay2.opened = true;
+          // Step 3: Closing overlay 1 so it's physically moved back from under the body
+          overlay1.opened = false;
+          // Step 4: Closing overlay 2 restores pointer-events of an overlay it
+          // finds under the body node, but overlay 1 is no longer there.
+          overlay2.opened = false;
+          // The fix: Clear pointer-events whenever an overlay is closed
+          // (in this case overlay 1 at step 3)
+          expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('auto');
+        });
       });
 
       it('should close on esc', () => {


### PR DESCRIPTION
Fixes #144 
Fixes #143 