### PR TITLE
refactor: reuse existing style scope info

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -787,18 +787,12 @@ This program is available under Apache License Version 2.0, available at https:/
             this.$.content.attachShadow({mode: 'open'});
           }
 
-          let scopeCssText = Array.from(templateRoot.querySelectorAll('style'))
-            .reduce((result, style) => result + style.textContent, '');
-
-          if (window.ShadyCSS && !window.ShadyCSS.nativeShadow) {
-            // NOTE(platosha): ShadyCSS removes <style>’s from templates, so
-            // we have to use these protected APIs to get their contents back
-            const styleInfo = window.ShadyCSS.ScopingShim
-              ._styleInfoForNode(templateRoot.host);
-            if (styleInfo) {
-              scopeCssText += styleInfo._getStyleRules().parsedCssText;
-              scopeCssText += '}';
-            }
+          let scopeCssText = '';
+          const host = templateRoot.host;
+          if (host && host.constructor.template) {
+            scopeCssText = Polymer.StyleGather
+              .stylesFromTemplate(host.constructor.template)
+              .reduce((result, style) => result + style.textContent, '');
           }
 
           // The overlay root’s :host styles should not apply inside the overlay


### PR DESCRIPTION
Connected to vaadin/vaadin-combo-box#767

This should slightly improve performance when initial stamping overlay by reusing already calculated styles info, and allows to avoid using private ShadyCSS API. This makes sense especially for combo-box, as there is no styles to teleport in `vaadin-combo-box-dropdown-wrapper`.