### PR TITLE
fix: ensure themable-mixin styles are applied

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -796,9 +796,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
           let scopeCssText = '';
           const host = templateRoot.host;
-          if (host && host.constructor.template) {
+          if (host && host._template) {
             scopeCssText = Polymer.StyleGather
-              .stylesFromTemplate(host.constructor.template)
+              .stylesFromTemplate(host._template)
               .reduce((result, style) => result + style.textContent, '');
           }
 

--- a/test/styling.html
+++ b/test/styling.html
@@ -12,6 +12,16 @@
 
 <body>
 
+  <dom-module id="theme-style-module" theme-for="local-styles">
+    <template>
+      <style>
+        .themed-styles-content {
+          font-family: ".themed-styles-content";
+        }
+      </style>
+    </template>
+  </dom-module>
+
   <dom-module id="local-styles">
     <template>
       <style>
@@ -32,13 +42,14 @@
         <template>
           <div class="local-styles-content"></div>
           <div class="global-styles-content"></div>
+          <div class="themed-styles-content"></div>
         </template>
       </vaadin-overlay>
     </template>
   </dom-module>
   <script>
     addEventListener('WebComponentsReady', () => {
-      customElements.define('local-styles', class extends Polymer.Element {
+      customElements.define('local-styles', class extends Vaadin.ThemableMixin(Polymer.Element) {
         static get is() {
           return 'local-styles';
         }
@@ -181,6 +192,12 @@
           expect(getComputedStyleSource(
             overlay.content.querySelector('.local-styles-content')
           )).to.equal('.local-styles-content');
+        });
+
+        it('should apply styles from themable mixin to overlay content', () => {
+          expect(getComputedStyleSource(
+            overlay.content.querySelector('.themed-styles-content')
+          )).to.equal('.themed-styles-content');
         });
 
         it('should not apply global styles to overlay content', () => {


### PR DESCRIPTION
The #149 introduced a regression with styles from `ThemableMixin` and this is the fix.
The `_template` is being set on the Polymer elements [_finalizeClass](https://github.com/Polymer/polymer/blob/187f10a556f103134871cfe951d6a4a724c177bc/lib/mixins/element-mixin.js#L365) method and that happens after the phase where ThemableMixin picks up styles.