### PR TITLE
fix: only set pointer-events for attached overlays

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -706,7 +706,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         // Disable pointer events in other attached overlays
         OverlayElement.__attachedInstances.forEach(el => {
-          if (el !== this) {
+          if (el !== this && !el.hasAttribute('opening') && !el.hasAttribute('closing')) {
             el.shadowRoot.querySelector('[part="overlay"]').style.pointerEvents = 'none';
           }
         });

--- a/test/animations.html
+++ b/test/animations.html
@@ -166,5 +166,27 @@
         });
       });
     });
+
+    describe('simultaneous opening', () => {
+      let wrapper, overlays;
+
+      beforeEach(() => {
+        wrapper = fixture('switching');
+        overlays = Array.from(wrapper.shadowRoot.querySelectorAll('vaadin-overlay'));
+        overlays.forEach(overlay => mockOverlayAnimations(overlay));
+      });
+
+      it('should not remove pointer events on last opened overlay', done => {
+        overlays[1].addEventListener('vaadin-overlay-open', e => {
+          Polymer.RenderStatus.afterNextRender(overlays[1], () => {
+            expect(overlays[0].$.overlay.style.pointerEvents).to.equal('none');
+            expect(overlays[1].$.overlay.style.pointerEvents).to.equal('');
+            done();
+          });
+        });
+        overlays[0].opened = true;
+        overlays[1].opened = true;
+      });
+    });
   </script>
 </body>


### PR DESCRIPTION
Fixes #152 
Fixes vaadin/vaadin-dialog-flow#121

The suggested fix is meant to ensure that `pointer-events` are set in the same order as `_enterModalState` has been called while opening overlays.

The original issue is a regression from #140 which didn't cover this edge case.