### PR TITLE
Prevent exception in children.length when children is undefined

### DIFF
--- a/src/vaadin-focusables-helper.html
+++ b/src/vaadin-focusables-helper.html
@@ -139,9 +139,11 @@
           // Use shadow root if possible, will check for distributed nodes.
           children = (element.shadowRoot || element).children;
         }
-        for (let i = 0; i < children ? children.length : 0; i++) {
-          // Ensure method is always invoked to collect tabbable children.
-          needsSort = this._collectTabbableNodes(children[i], result) || needsSort;
+        if (children) {
+          for (let i = 0; i < children.length; i++) {
+            // Ensure method is always invoked to collect tabbable children.
+            needsSort = this._collectTabbableNodes(children[i], result) || needsSort;
+          }
         }
         return needsSort;
       },

--- a/src/vaadin-focusables-helper.html
+++ b/src/vaadin-focusables-helper.html
@@ -139,7 +139,7 @@
           // Use shadow root if possible, will check for distributed nodes.
           children = (element.shadowRoot || element).children;
         }
-        for (let i = 0; i < children.length; i++) {
+        for (let i = 0; i < children ? children.length : 0; i++) {
           // Ensure method is always invoked to collect tabbable children.
           needsSort = this._collectTabbableNodes(children[i], result) || needsSort;
         }

--- a/test/focus-trap.html
+++ b/test/focus-trap.html
@@ -115,6 +115,8 @@
       <vaadin-overlay focus-trap="">
         <template>
           <container-with-shadow></container-with-shadow>
+          <!-- On IE11 SVGElement#children returns undefined instead of an empty HTMLCollection -->
+          <svg></svg>
           <input type="text" id="text">
         </template>
       </vaadin-overlay>


### PR DESCRIPTION
On IE11, SVGElement#children returns undefined instead of an empty HTMLCollection
This was originally reported in https://github.com/PolymerElements/iron-overlay-behavior/issues/283