### PR TITLE
Revert "Restore focus on focusout (#162)"

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -410,18 +410,6 @@ This program is available under Apache License Version 2.0, available at https:/
         // and <vaadin-context-menu>).
         this.addEventListener('click', () => {});
         this.$.backdrop.addEventListener('click', () => {});
-
-        // Make sure the focus stays within the overlay (even on caret browsing)
-        this.addEventListener('focusout', e => {
-          const related = e.relatedTarget;
-          if (this.focusTrap && (!related || !this._deepContains(related))) {
-            setTimeout(() => {
-              this.tabIndex = -1;
-              this.focus();
-              this.tabIndex = undefined;
-            });
-          }
-        });
       }
 
       _detectIosNavbar() {

--- a/test/focus-trap.html
+++ b/test/focus-trap.html
@@ -167,25 +167,6 @@
           overlay.opened = true;
         });
 
-        it('should restore focus on focusout', done => {
-          const spy = sinon.spy(overlay, 'focus');
-          overlay.dispatchEvent(new CustomEvent('focusout'));
-          setTimeout(() => {
-            expect(spy.called).to.be.true;
-            done();
-          });
-        });
-
-        it('should not restore focus on focusout if not a focustrap', done => {
-          overlay.focusTrap = false;
-          const spy = sinon.spy(overlay, 'focus');
-          overlay.dispatchEvent(new CustomEvent('focusout'));
-          setTimeout(() => {
-            expect(spy.called).to.be.false;
-            done();
-          });
-        });
-
         it('should properly detect focusable elements inside the content', () => {
           expect(focusableElements.length).to.eql(11);
           expect(focusableElements[0]).to.eql(overlay.content.querySelector('textarea'));


### PR DESCRIPTION
This reverts commit 4d14943803a1febeec2ef8ea2e64a6101c176b08.

Fixes https://github.com/vaadin/vaadin-confirm-dialog-flow/issues/105