### PR TITLE
refactor: do not apply position mixin to overlay for now

### DIFF
--- a/src/vaadin-overlay-position-mixin.html
+++ b/src/vaadin-overlay-position-mixin.html
@@ -14,7 +14,7 @@ This program is available under Apache License Version 2.0, available at https:/
   /**
    * @polymerMixin
    */
-  Vaadin.Overlay.PositionMixin = superClass => class PositionMixin extends superClass {
+  Vaadin.Overlay._PositionMixin = superClass => class PositionMixin extends superClass {
 
     static get properties() {
       return {
@@ -93,6 +93,12 @@ This program is available under Apache License Version 2.0, available at https:/
           this._updatePosition();
         }
       });
+    }
+
+    ready() {
+      super.ready();
+
+      console.warn('PositionMixin is not considered stable and might change any time');
     }
 
     __positionSettingsChanged() {

--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -236,7 +236,6 @@ This program is available under Apache License Version 2.0, available at https:/
      *
      * @memberof Vaadin
      * @mixes Vaadin.ThemableMixin
-     * @mixes Vaadin.Overlay.PositionMixin
      * @demo demo/index.html
      */
     class OverlayElement extends Vaadin.ThemableMixin(Polymer.Element) {

--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -10,7 +10,6 @@ This program is available under Apache License Version 2.0, available at https:/
 <link rel="import" href="../../polymer/lib/utils/flattened-nodes-observer.html">
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
 <link rel="import" href="vaadin-focusables-helper.html">
-<link rel="import" href="vaadin-overlay-position-mixin.html">
 
 <dom-module id="vaadin-overlay">
   <template>
@@ -240,9 +239,7 @@ This program is available under Apache License Version 2.0, available at https:/
      * @mixes Vaadin.Overlay.PositionMixin
      * @demo demo/index.html
      */
-    class OverlayElement extends Vaadin.ThemableMixin(
-      Vaadin.Overlay.PositionMixin(
-        Polymer.Element)) {
+    class OverlayElement extends Vaadin.ThemableMixin(Polymer.Element) {
 
       static get is() {
         return 'vaadin-overlay';

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -4,6 +4,7 @@
     "describe": false,
     "afterEach": false,
     "beforeEach": false,
+    "before": false,
     "fixture": false,
     "it": false,
     "expect": false,

--- a/test/position-target.html
+++ b/test/position-target.html
@@ -7,6 +7,7 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-overlay.html">
+  <link rel="import" href="../src/vaadin-overlay-position-mixin.html">
 </head>
 
 <body>
@@ -27,21 +28,32 @@
     }
   </style>
 
+  <script>
+    customElements.whenDefined('vaadin-overlay').then(() => {
+      class PositionedOverlay extends Vaadin.Overlay.PositionMixin(Vaadin.OverlayElement) {
+        static get is() {
+          return 'vaadin-positioned-overlay';
+        }
+      }
+
+      customElements.define(PositionedOverlay.is, PositionedOverlay);
+    });
+  </script>
+
   <test-fixture id="default">
     <template>
       <div id="parent">
         <div id="target">target</div>
-        <vaadin-overlay id="overlay">
+        <vaadin-positioned-overlay id="overlay">
           <template>
             <div id="overlay-child"></div>
           </template>
-        </vaadin-overlay>
+        </vaadin-positioned-overlay>
       </div>
     </template>
   </test-fixture>
 
   <script>
-
     describe('position target', () => {
 
       const TOP = 'top', BOTTOM = 'bottom';

--- a/test/position-target.html
+++ b/test/position-target.html
@@ -30,7 +30,7 @@
 
   <script>
     customElements.whenDefined('vaadin-overlay').then(() => {
-      class PositionedOverlay extends Vaadin.Overlay.PositionMixin(Vaadin.OverlayElement) {
+      class PositionedOverlay extends Vaadin.Overlay._PositionMixin(Vaadin.OverlayElement) {
         static get is() {
           return 'vaadin-positioned-overlay';
         }

--- a/test/position-target.html
+++ b/test/position-target.html
@@ -29,7 +29,17 @@
   </style>
 
   <script>
-    customElements.whenDefined('vaadin-overlay').then(() => {
+    const importsReady = () => {
+      return new Promise(resolve => {
+        if (window.HTMLImports && window.HTMLImports.whenReady) {
+          window.HTMLImports.whenReady(resolve);
+        } else {
+          customElements.whenDefined('vaadin-overlay').then(resolve);
+        }
+      });
+    };
+
+    importsReady().then(() => {
       class PositionedOverlay extends Vaadin.Overlay._PositionMixin(Vaadin.OverlayElement) {
         static get is() {
           return 'vaadin-positioned-overlay';
@@ -77,6 +87,10 @@
       function setRTL() {
         overlay.setAttribute('dir', 'rtl');
       }
+
+      before(done => {
+        customElements.whenDefined('vaadin-positioned-overlay').then(done);
+      });
 
       beforeEach(() => {
         const parent = fixture('default');


### PR DESCRIPTION
We need to deliver `bringToFront` API in a next minor which is 3.3.0
Let's exclude this mixin from there as we are not using it yet.