### PR TITLE
Extend DirMixin

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
   ],
   "dependencies": {
     "polymer": "^2.0.0",
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.0",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.3.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.2.0"

--- a/demo/index.html
+++ b/demo/index.html
@@ -157,7 +157,8 @@
       </template>
     </demo-snippet>
 
-    <h3>Position Target</h3>
+    <!-- Demo disabled because PositionMixin is not considered stable and might change any time -->
+    <!-- <h3>Position Target</h3>
     <demo-snippet>
       <template>
         <vaadin-overlay id="positionOverlay" opened modeless></vaadin-overlay>
@@ -195,7 +196,7 @@
           };
         </script>
       </template>
-    </demo-snippet>
+    </demo-snippet> -->
 
     <h3>Restore Focus on Close</h3>
     <demo-snippet>
@@ -293,11 +294,14 @@
             overlayPointer.renderer = function(root) {
               root.textContent = 'I am next to the pointer';
             };
+            const isRtl = overlayPointer.getAttribute('rtl');
             overlayPointer.setAttribute(
               'style',
               'left: ' + event.clientX + 'px;' +
               'top: ' + event.clientY + 'px;' +
-              'align-items: flex-start; justify-content: flex-start;'
+              'align-items: flex-' +
+              (isRtl ? 'start' : 'end') +
+              '; justify-content: flex-start;'
             );
             overlayPointer.opened = true;
           });

--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -9,6 +9,7 @@ This program is available under Apache License Version 2.0, available at https:/
 <link rel="import" href="../../polymer/lib/utils/render-status.html">
 <link rel="import" href="../../polymer/lib/utils/flattened-nodes-observer.html">
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
+<link rel="import" href="../../vaadin-element-mixin/vaadin-dir-mixin.html">
 <link rel="import" href="vaadin-focusables-helper.html">
 
 <dom-module id="vaadin-overlay">
@@ -238,7 +239,7 @@ This program is available under Apache License Version 2.0, available at https:/
      * @mixes Vaadin.ThemableMixin
      * @demo demo/index.html
      */
-    class OverlayElement extends Vaadin.ThemableMixin(Polymer.Element) {
+    class OverlayElement extends Vaadin.ThemableMixin(Vaadin.DirMixin(Polymer.Element)) {
 
       static get is() {
         return 'vaadin-overlay';


### PR DESCRIPTION
Connected to #171 
Extend DirMixin for RTL support.
Removed `Position Target` demo

Overlay should extend the `dir-mixin`, so rtl specific styles can be applied to `vaadin-select-overlay` and `vaadin-context-menu-overlay`