### PR TITLE
fix: Exclude closing overlays from __attachedInstances (#180)

### DIFF
--- a/src/vaadin-overlay.html
+++ b/src/vaadin-overlay.html
@@ -672,7 +672,8 @@ This program is available under Apache License Version 2.0, available at https:/
        * Returns all attached overlays.
        */
       static get __attachedInstances() {
-        return Array.from(document.body.children).filter(el => el instanceof OverlayElement);
+        return Array.from(document.body.children)
+          .filter(el => el instanceof OverlayElement && !el.hasAttribute('closing'));
       }
 
       /**

--- a/test/animations.html
+++ b/test/animations.html
@@ -278,6 +278,34 @@
         });
       });
 
+      describe(`simultaneous closing${titleSuffix}`, () => {
+        let wrapper, overlays;
+
+        beforeEach(() => {
+          wrapper = fixture('switching');
+          const third = document.createElement('vaadin-overlay');
+          wrapper.shadowRoot.appendChild(third);
+          overlays = Array.from(wrapper.shadowRoot.querySelectorAll('vaadin-overlay'));
+
+          if (withAnimation) {
+            overlays.forEach(overlay => overlay.setAttribute('animate', ''));
+          }
+        });
+
+        it('should restore pointer events on the remaining overlay', done => {
+          afterOverlayOpeningFinished(overlays[2], () => {
+            expect(overlays[0].$.overlay.style.pointerEvents).to.equal('none');
+            overlays[1].opened = false;
+            overlays[2].opened = false;
+            expect(overlays[0].$.overlay.style.pointerEvents).to.equal('');
+            done();
+          });
+          overlays[0].opened = true;
+          overlays[1].opened = true;
+          overlays[2].opened = true;
+        });
+      });
+
       describe(`simultaneous opening with animated content${titleSuffix}`, () => {
         let wrapper, overlays;
 


### PR DESCRIPTION
Cherry pick of #180